### PR TITLE
Make jni:setup build all native libraries

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -404,7 +404,7 @@ jobs:
       - name: Run standalone example
         run: |
           dart pub get
-          dart run jni:setup && dart run jni:setup -p pdfbox_plugin
+          dart run jni:setup
           wget 'https://dart.dev/guides/language/specifications/DartLangSpec-v2.2.pdf'
           dart run bin/pdf_info.dart DartLangSpec-v2.2.pdf
         working-directory: ./jnigen/example/pdfbox_plugin/dart_example

--- a/jni/bin/setup.dart
+++ b/jni/bin/setup.dart
@@ -11,7 +11,7 @@ const ansiRed = '\x1b[31m';
 const ansiDefault = '\x1b[39;49m';
 
 const jniNativeBuildDirective =
-    '# jni_native_build (Build with jni:setup. Do not delete this line)';
+    '# jni_native_build (Build with jni:setup. Do not delete this line.)';
 
 const _defaultRelativeBuildPath = "build/jni_libs";
 

--- a/jni/bin/setup.dart
+++ b/jni/bin/setup.dart
@@ -13,8 +13,8 @@ const ansiDefault = '\x1b[39;49m';
 const _defaultRelativeBuildPath = "build/jni_libs";
 
 const _buildPath = "build-path";
-const _srcPath = "source-path";
-const _packageName = 'package-name';
+const _srcPath = "add-source";
+const _packageName = 'add-package';
 const _verbose = "verbose";
 const _cmakeArgs = "cmake-args";
 
@@ -65,13 +65,14 @@ Future<void> runCommand(
 class Options {
   Options(ArgResults arg)
       : buildPath = arg[_buildPath],
-        srcPath = arg[_srcPath],
-        packageName = arg[_packageName] ?? 'jni',
+        sources = arg[_srcPath],
+        packages = arg[_packageName],
         cmakeArgs = arg[_cmakeArgs],
         verbose = arg[_verbose] ?? false;
 
-  String? buildPath, srcPath;
-  String packageName;
+  String? buildPath;
+  List<String> sources;
+  List<String> packages;
   List<String> cmakeArgs;
   bool verbose;
 }
@@ -88,16 +89,36 @@ void verboseLog(String msg) {
 ///
 /// It's assumed C FFI sources are in "src/" relative to package root.
 /// If package cannot be found, null is returned.
-Future<String?> findSources(String packageName) async {
+Future<String> findSources(String packageName) async {
   final packageConfig = await findPackageConfig(Directory.current);
   if (packageConfig == null) {
-    return null;
+    throw UnsupportedError("Please run from project root.");
   }
-  final package = packageConfig[options.packageName];
+  final package = packageConfig[packageName];
   if (package == null) {
-    return null;
+    throw UnsupportedError("Cannot find package: $packageName");
   }
   return package.root.resolve("src").toFilePath();
+}
+
+/// Return '/src' directories of all dependencies which has a CMakeLists.txt
+/// file.
+///
+/// TODO(PR): Should this rather check for ffiPlugin property of pubspecs?
+Future<Map<String, String>> findDependencySources() async {
+  final packageConfig = await findPackageConfig(Directory.current);
+  if (packageConfig == null) {
+    throw UnsupportedError("Please run the command from project root.");
+  }
+  final sources = <String, String>{};
+  for (var package in packageConfig.packages) {
+    final src = package.root.resolve("src/");
+    final cmakeLists = src.resolve("CMakeLists.txt");
+    if (File.fromUri(cmakeLists).existsSync()) {
+      sources[package.name] = src.toFilePath();
+    }
+  }
+  return sources;
 }
 
 /// Returns true if [artifact] does not exist, or any file in [sourceDir] is
@@ -129,13 +150,12 @@ void main(List<String> arguments) async {
   final parser = ArgParser()
     ..addOption(_buildPath,
         abbr: 'b', help: 'Directory to place built artifacts')
-    ..addOption(_srcPath,
+    ..addMultiOption(_srcPath,
         abbr: 's', help: 'alternative path to package:jni sources')
-    ..addOption(_packageName,
+    ..addMultiOption(_packageName,
         abbr: 'p',
         help: 'package for which native'
-            'library should be built',
-        defaultsTo: 'jni')
+            'library should be built')
     ..addFlag(_verbose, abbr: 'v', help: 'Enable verbose output')
     ..addMultiOption(_cmakeArgs,
         abbr: 'm', help: 'Pass additional argument to CMake');
@@ -151,69 +171,73 @@ void main(List<String> arguments) async {
     return;
   }
 
-  final srcPath = options.srcPath ?? await findSources(options.packageName);
-
-  if (srcPath == null) {
-    stderr.writeln("Cannot find sources for package ${options.packageName} "
-        "and no sources were manually specified.");
+  final sources = options.sources;
+  for (var packageName in options.packages) {
+    sources.add(await findSources(packageName));
+  }
+  if (sources.isEmpty) {
+    final dependencySources = await findDependencySources();
+    stderr.writeln("selecting source directories for dependencies: "
+        "${dependencySources.keys}");
+    sources.addAll(dependencySources.values);
+  } else {
+    stderr.writeln("selecting source directories: $sources");
+  }
+  if (sources.isEmpty) {
+    stderr.writeln('No source paths to build!');
     exitCode = 1;
     return;
   }
-
-  final srcDir = Directory(srcPath);
-  if (!srcDir.existsSync()) {
-    stderr.writeln('Directory $srcPath does not exist');
-    exitCode = 1;
-    return;
-  }
-
-  verboseLog("srcPath: $srcPath");
-
-  final currentDirUri = Uri.directory(".");
-  final buildPath = options.buildPath ??
-      currentDirUri.resolve(_defaultRelativeBuildPath).toFilePath();
-  final buildDir = Directory(buildPath);
-  await buildDir.create(recursive: true);
-  verboseLog("buildPath: $buildPath");
-
-  if (buildDir.absolute.uri == srcDir.absolute.uri) {
-    stderr.writeln("Please build in a directory different than source.");
-    exitCode = 1;
-    return;
-  }
-
-  final targetFileUri = buildDir.uri.resolve(getTargetName(srcDir));
-  final targetFile = File.fromUri(targetFileUri);
-  if (!needsBuild(targetFile, srcDir)) {
-    verboseLog("last modified of ${targetFile.path}: "
-        "${targetFile.lastModifiedSync()}");
-    stderr.writeln("target newer than source, skipping build");
-    return;
-  }
-
-  // Note: creating temp dir in .dart_tool/jni instead of SystemTemp
-  // because latter can fail tests on Windows CI, when system temp is on
-  // separate drive or something.
-  final jniDirUri = Uri.directory(".dart_tool").resolve("jni");
-  final jniDir = Directory.fromUri(jniDirUri);
-  await jniDir.create(recursive: true);
-  final tempDir = await jniDir.createTemp("jni_native_build_");
-  final cmakeArgs = <String>[];
-  cmakeArgs.addAll(options.cmakeArgs);
-  // Pass absolute path of srcDir because cmake command is run in temp dir
-  cmakeArgs.add(srcDir.absolute.path);
-  await runCommand("cmake", cmakeArgs, tempDir.path);
-  await runCommand("cmake", ["--build", "."], tempDir.path);
-  final dllDirUri =
-      Platform.isWindows ? tempDir.uri.resolve("Debug") : tempDir.uri;
-  final dllDir = Directory.fromUri(dllDirUri);
-  for (var entry in dllDir.listSync()) {
-    final dllSuffix = Platform.isWindows ? "dll" : "so";
-    if (entry.path.endsWith(dllSuffix)) {
-      final dllName = entry.uri.pathSegments.last;
-      final target = buildDir.uri.resolve(dllName);
-      entry.renameSync(target.toFilePath());
+  for (var srcPath in sources) {
+    final srcDir = Directory(srcPath);
+    if (!srcDir.existsSync()) {
+      stderr.writeln('Directory $srcPath does not exist');
+      exitCode = 1;
+      return;
     }
+
+    verboseLog("srcPath: $srcPath");
+
+    final currentDirUri = Uri.directory(".");
+    final buildPath = options.buildPath ??
+        currentDirUri.resolve(_defaultRelativeBuildPath).toFilePath();
+    final buildDir = Directory(buildPath);
+    await buildDir.create(recursive: true);
+    verboseLog("buildPath: $buildPath");
+
+    final targetFileUri = buildDir.uri.resolve(getTargetName(srcDir));
+    final targetFile = File.fromUri(targetFileUri);
+    if (!needsBuild(targetFile, srcDir)) {
+      verboseLog("last modified of ${targetFile.path}: "
+          "${targetFile.lastModifiedSync()}");
+      stderr.writeln("target newer than source, skipping build");
+      continue;
+    }
+
+    // Note: creating temp dir in .dart_tool/jni instead of SystemTemp
+    // because latter can fail tests on Windows CI, when system temp is on
+    // separate drive or something.
+    final jniDirUri = Uri.directory(".dart_tool").resolve("jni");
+    final jniDir = Directory.fromUri(jniDirUri);
+    await jniDir.create(recursive: true);
+    final tempDir = await jniDir.createTemp("jni_native_build_");
+    final cmakeArgs = <String>[];
+    cmakeArgs.addAll(options.cmakeArgs);
+    // Pass absolute path of srcDir because cmake command is run in temp dir
+    cmakeArgs.add(srcDir.absolute.path);
+    await runCommand("cmake", cmakeArgs, tempDir.path);
+    await runCommand("cmake", ["--build", "."], tempDir.path);
+    final dllDirUri =
+        Platform.isWindows ? tempDir.uri.resolve("Debug") : tempDir.uri;
+    final dllDir = Directory.fromUri(dllDirUri);
+    for (var entry in dllDir.listSync()) {
+      final dllSuffix = Platform.isWindows ? "dll" : "so";
+      if (entry.path.endsWith(dllSuffix)) {
+        final dllName = entry.uri.pathSegments.last;
+        final target = buildDir.uri.resolve(dllName);
+        entry.renameSync(target.toFilePath());
+      }
+    }
+    await tempDir.delete(recursive: true);
   }
-  await tempDir.delete(recursive: true);
 }

--- a/jni/bin/setup.dart
+++ b/jni/bin/setup.dart
@@ -10,7 +10,8 @@ import 'package:package_config/package_config.dart';
 const ansiRed = '\x1b[31m';
 const ansiDefault = '\x1b[39;49m';
 
-const jniNativeBuildDirective = '# jnigen_native_build';
+const jniNativeBuildDirective =
+    '# jni_native_build (Build with jni:setup. Do not delete this line)';
 
 const _defaultRelativeBuildPath = "build/jni_libs";
 

--- a/jni/lib/jni.dart
+++ b/jni/lib/jni.dart
@@ -30,13 +30,14 @@
 /// This module depends on a shared library written in C. Therefore on dart
 /// standalone:
 ///
-/// * Run `dart run jni:setup` to build the shared library. The default output
-/// directory is build/jni_libs, which can be changed using `-B` switch.
+/// * Run `dart run jni:setup` to build the shared library. This command builds
+/// all dependency libraries with native code (package:jni and jnigen-generated)
+/// libraries if any.
+///
+/// The default output directory is build/jni_libs, which can be changed
+/// using `-B` switch.
 ///
 /// * Provide the location of library to `Jni.spawn` call.
-///
-/// * If there are generated libraries (using jnigen), also build them using
-/// the command: `dart run jni:setup -p package_name` in the same directory.
 ///
 /// ## JNIEnv
 /// `GlobalJniEnv` type provides a thin wrapper over `JNIEnv*` which can be used

--- a/jni/src/CMakeLists.txt
+++ b/jni/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+# jnigen_native_build
+
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.

--- a/jni/src/CMakeLists.txt
+++ b/jni/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jnigen_native_build
+# jni_native_build (Build with jni:setup. Do not delete this line)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jni/src/CMakeLists.txt
+++ b/jni/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jni_native_build (Build with jni:setup. Do not delete this line)
+# jni_native_build (Build with jni:setup. Do not delete this line.)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/cmake/CMakeLists.txt.tmpl
+++ b/jnigen/cmake/CMakeLists.txt.tmpl
@@ -1,3 +1,5 @@
+# jnigen_native_build
+
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.

--- a/jnigen/cmake/CMakeLists.txt.tmpl
+++ b/jnigen/cmake/CMakeLists.txt.tmpl
@@ -1,4 +1,4 @@
-# jnigen_native_build
+# jni_native_build (Build with jni:setup. Do not delete this line)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/cmake/CMakeLists.txt.tmpl
+++ b/jnigen/cmake/CMakeLists.txt.tmpl
@@ -1,4 +1,4 @@
-# jni_native_build (Build with jni:setup. Do not delete this line)
+# jni_native_build (Build with jni:setup. Do not delete this line.)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/example/README.md
+++ b/jnigen/example/README.md
@@ -20,7 +20,7 @@ Currently supported platforms are Linux (Standalone, Flutter), and Android (Flut
 * Generate JNI bindings by running `dart run jnigen --config jnigen.yaml`.
 
 * In the CLI project which uses this package, add this package, and `jni` as a dependency.
-* Run `dart run jni:setup && dart run jni:setup -p <generated_package_name>` to build native libraries for JNI base library and your package respectively.
+* Run `dart run jni:setup` to build native libraries for JNI base library and jnigen generated package.
 * Import the package. See [pdf_info.dart](pdfbox_plugin/dart_example/bin/pdf_info.dart) for how to use the JNI from dart standalone.
 
 ### Flutter FFI plugin

--- a/jnigen/example/in_app_java/src/android_utils/CMakeLists.txt
+++ b/jnigen/example/in_app_java/src/android_utils/CMakeLists.txt
@@ -1,3 +1,5 @@
+# jnigen_native_build
+
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.

--- a/jnigen/example/in_app_java/src/android_utils/CMakeLists.txt
+++ b/jnigen/example/in_app_java/src/android_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jnigen_native_build
+# jni_native_build (Build with jni:setup. Do not delete this line)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/example/in_app_java/src/android_utils/CMakeLists.txt
+++ b/jnigen/example/in_app_java/src/android_utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jni_native_build (Build with jni:setup. Do not delete this line)
+# jni_native_build (Build with jni:setup. Do not delete this line.)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/example/notification_plugin/src/CMakeLists.txt
+++ b/jnigen/example/notification_plugin/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+# jnigen_native_build
+
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.

--- a/jnigen/example/notification_plugin/src/CMakeLists.txt
+++ b/jnigen/example/notification_plugin/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jnigen_native_build
+# jni_native_build (Build with jni:setup. Do not delete this line)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/example/notification_plugin/src/CMakeLists.txt
+++ b/jnigen/example/notification_plugin/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jni_native_build (Build with jni:setup. Do not delete this line)
+# jni_native_build (Build with jni:setup. Do not delete this line.)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/example/pdfbox_plugin/dart_example/README.md
+++ b/jnigen/example/pdfbox_plugin/dart_example/README.md
@@ -1,7 +1,7 @@
 ## Running
 After generating `pdfbox_plugin` bindings in the parent directory
 
-* setup native libraries: `dart run jni:setup && dart run jni:setup -p pdfbox_plugin`
+* setup native libraries: `dart run jni:setup`
 
 * `dart run bin/pdf_info.dart <Path_to_PDF_File>`
 

--- a/jnigen/example/pdfbox_plugin/src/CMakeLists.txt
+++ b/jnigen/example/pdfbox_plugin/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+# jnigen_native_build
+
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.

--- a/jnigen/example/pdfbox_plugin/src/CMakeLists.txt
+++ b/jnigen/example/pdfbox_plugin/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jnigen_native_build
+# jni_native_build (Build with jni:setup. Do not delete this line)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/example/pdfbox_plugin/src/CMakeLists.txt
+++ b/jnigen/example/pdfbox_plugin/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jni_native_build (Build with jni:setup. Do not delete this line)
+# jni_native_build (Build with jni:setup. Do not delete this line.)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/test/bindings_test.dart
+++ b/jnigen/test/bindings_test.dart
@@ -27,11 +27,16 @@ final jacksonCoreTest = join('test', 'jackson_core_test');
 final simplePackageTestJava = join(simplePackageTest, 'java');
 
 Future<void> setupDylibsAndClasses() async {
-  await runCommand('dart', ['run', 'jni:setup']);
-  await runCommand(
-      'dart', ['run', 'jni:setup', '-s', join(simplePackageTest, 'src')]);
-  await runCommand('dart',
-      ['run', 'jni:setup', '-s', join(jacksonCoreTest, 'third_party', 'src')]);
+  await runCommand('dart', [
+    'run',
+    'jni:setup',
+    '-p',
+    'jni',
+    '-s',
+    join(simplePackageTest, 'src'),
+    '-s',
+    join(jacksonCoreTest, 'third_party', 'src')
+  ]);
   final group = join('com', 'github', 'dart_lang', 'jnigen');
   await runCommand(
       'javac',

--- a/jnigen/test/jackson_core_test/third_party/src/CMakeLists.txt
+++ b/jnigen/test/jackson_core_test/third_party/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+# jnigen_native_build
+
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.

--- a/jnigen/test/jackson_core_test/third_party/src/CMakeLists.txt
+++ b/jnigen/test/jackson_core_test/third_party/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jnigen_native_build
+# jni_native_build (Build with jni:setup. Do not delete this line)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/test/jackson_core_test/third_party/src/CMakeLists.txt
+++ b/jnigen/test/jackson_core_test/third_party/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jni_native_build (Build with jni:setup. Do not delete this line)
+# jni_native_build (Build with jni:setup. Do not delete this line.)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/test/simple_package_test/src/CMakeLists.txt
+++ b/jnigen/test/simple_package_test/src/CMakeLists.txt
@@ -1,3 +1,5 @@
+# jnigen_native_build
+
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause
 # the plugin to fail to compile for some customers of the plugin.

--- a/jnigen/test/simple_package_test/src/CMakeLists.txt
+++ b/jnigen/test/simple_package_test/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jnigen_native_build
+# jni_native_build (Build with jni:setup. Do not delete this line)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause

--- a/jnigen/test/simple_package_test/src/CMakeLists.txt
+++ b/jnigen/test/simple_package_test/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-# jni_native_build (Build with jni:setup. Do not delete this line)
+# jni_native_build (Build with jni:setup. Do not delete this line.)
 
 # The Flutter tooling requires that developers have CMake 3.10 or later
 # installed. You should not increase this version, as doing so will cause


### PR DESCRIPTION
Motivation explained in #91 .

This code is checking for a src/CMakeLists.txt in every package. Should it check for ffiPlugin key in pubspec instead?