### PR TITLE
Add regenerate script

### DIFF
--- a/jnigen/tool/command_runner.dart
+++ b/jnigen/tool/command_runner.dart
@@ -42,6 +42,7 @@ class Command implements Step {
       exec,
       args,
       workingDirectory: workingDirectory.toFilePath(),
+      runInShell: true,
     );
     if (result.exitCode != 0) {
       printError(result.stdout);

--- a/jnigen/tool/command_runner.dart
+++ b/jnigen/tool/command_runner.dart
@@ -1,0 +1,108 @@
+import 'dart:io';
+
+const ansiRed = '\x1b[31m';
+const ansiDefault = '\x1b[39;49m';
+
+void printError(Object? message) {
+  if (stderr.supportsAnsiEscapes) {
+    message = '$ansiRed$message$ansiDefault';
+  }
+  stderr.writeln(message);
+}
+
+class StepFailure implements Exception {
+  StepFailure(this.name);
+  String name;
+  @override
+  String toString() => 'step failed: $name';
+}
+
+abstract class Step {
+  /// Runs this step, raises an exception if something fails.
+  Future<void> run();
+}
+
+class Callback implements Step {
+  Callback(this.name, this.function);
+  String name;
+  Future<void> Function() function;
+  @override
+  Future<void> run() => function();
+}
+
+class Command implements Step {
+  Command(this.exec, this.args, this.workingDirectory);
+  final String exec;
+  final List<String> args;
+  final Uri workingDirectory;
+
+  @override
+  Future<void> run() async {
+    final result = await Process.run(
+      exec,
+      args,
+      workingDirectory: workingDirectory.toFilePath(),
+    );
+    if (result.exitCode != 0) {
+      printError(result.stdout);
+      printError(result.stderr);
+      final commandString = "$exec ${args.join(" ")}";
+      stderr.writeln("failure executing command: $commandString");
+      throw StepFailure(commandString);
+    }
+  }
+}
+
+class Runner {
+  static final gitRoot = getRepositoryRoot();
+  Runner(this.name, this.defaultWorkingDir);
+  String name;
+  Uri defaultWorkingDir;
+  final steps = <Step>[];
+  final cleanupSteps = <Step>[];
+
+  void chainCommand(String exec, List<String> args, {Uri? workingDirectory}) =>
+      _addCommand(steps, exec, args, workingDirectory: workingDirectory);
+
+  void chainCleanupCommand(String exec, List<String> args,
+          {Uri? workingDirectory}) =>
+      _addCommand(cleanupSteps, exec, args, workingDirectory: workingDirectory);
+
+  void _addCommand(List<Step> list, String exec, List<String> args,
+      {Uri? workingDirectory}) {
+    list.add(Command(exec, args, (workingDirectory ?? defaultWorkingDir)));
+  }
+
+  void chainCallback(String name, Future<void> Function() callback) {
+    steps.add(Callback(name, callback));
+  }
+
+  Future<void> run() async {
+    stderr.writeln("started: $name");
+    var error = false;
+    for (var step in steps) {
+      try {
+        await step.run();
+      } on StepFailure catch (e) {
+        stderr.writeln(e);
+        error = true;
+        exitCode = 1;
+        break;
+      }
+    }
+    stderr.writeln('${error ? "failed" : "complete"}: $name');
+    for (var step in cleanupSteps) {
+      try {
+        await step.run();
+      } on Exception catch (e) {
+        printError("ERROR: $e");
+      }
+    }
+  }
+}
+
+Uri getRepositoryRoot() {
+  final gitCommand = Process.runSync("git", ["rev-parse", "--show-toplevel"]);
+  final output = gitCommand.stdout as String;
+  return Uri.directory(output.trim());
+}

--- a/jnigen/tool/regenerate_all_bindings.dart
+++ b/jnigen/tool/regenerate_all_bindings.dart
@@ -3,6 +3,8 @@
 // BSD-style license that can be found in the LICENSE file.
 
 // Run this script after any change which affects generated bindings.
+//
+// This will update all generated bindings in the whole repository.
 
 import 'dart:io';
 

--- a/jnigen/tool/regenerate_bindings.dart
+++ b/jnigen/tool/regenerate_bindings.dart
@@ -1,0 +1,37 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Run this script after any change which affects generated bindings.
+
+import 'dart:io';
+
+import 'command_runner.dart';
+
+const scripts = [
+  "test/jackson_core_test/generate.dart",
+  "test/simple_package_test/generate.dart",
+];
+
+const yamlBasedExamples = [
+  "example/in_app_java",
+  "example/pdfbox_plugin",
+  "example/notification_plugin",
+];
+
+void main() async {
+  final runners = <Runner>[];
+  final current = Directory.current.uri;
+  for (var script in scripts) {
+    runners.add(Runner("Run generate script: $script", current)
+      ..chainCommand("dart", ["run", script]));
+  }
+
+  for (var yamlDir in yamlBasedExamples) {
+    runners.add(
+        Runner("Regenerate bindings in $yamlDir", current.resolve(yamlDir))
+          ..chainCommand("dart", ["run", "jnigen", "--config", "jnigen.yaml"]));
+  }
+
+  await Future.wait(runners.map((runner) => runner.run()).toList());
+}


### PR DESCRIPTION
Changes summary:

* Move general functionality from `pre_commit_checks.dart` to `command_runner.dart`.

* Add `tool/regenerate_bindings.dart` to generate bindings after any change affecting bindings.

* Make `pre_commit_checks.dart` run (most) checks in cloned directory instead of original.
  - This required me to use URI everywhere, because strange things happen on Windows.