### PR TITLE
Fix the example hyperlink

### DIFF
--- a/jnigen/README.md
+++ b/jnigen/README.md
@@ -1,6 +1,6 @@
 # Experimental generator for FFI+JNI bindings.
 
-This package consists of the code generator `package:jnigen` and a few [example](examples).
+This package consists of the code generator `package:jnigen` and a few [example](example).
 
 See the [README](../README.md) at the root of this repository for a technical introduction and usage reference.
 


### PR DESCRIPTION
The example hyperlink is broken. This patch fixes it.