### PR TITLE
Use `package:cli_config`

### DIFF
--- a/jnigen/bin/jnigen.dart
+++ b/jnigen/bin/jnigen.dart
@@ -12,6 +12,9 @@ void main(List<String> args) async {
   } on ConfigException catch (e) {
     log.fatal(e);
     return;
+  } on FormatException catch (e) {
+    log.fatal(e);
+    return;
   }
   await generateJniBindings(config);
 }

--- a/jnigen/lib/src/config/yaml_reader.dart
+++ b/jnigen/lib/src/config/yaml_reader.dart
@@ -104,13 +104,8 @@ class YamlReader {
     return configResult?.map((e) => e.path).toList();
   }
 
-  String? getOneOf(String property, Set<String> values) {
-    final value = _config.optionalString(property);
-    if (value == null || values.contains(value)) {
-      return value;
-    }
-    throw ConfigException('expected one of $values for $property');
-  }
+  String? getOneOf(String property, Set<String> values) =>
+      _config.optionalString(property, validValues: values);
 
   Map<String, String>? getStringMap(String property) {
     final value = _config.valueOf<YamlMap?>(property);

--- a/jnigen/lib/src/config/yaml_reader.dart
+++ b/jnigen/lib/src/config/yaml_reader.dart
@@ -6,15 +6,17 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:yaml/yaml.dart';
+import 'package:cli_config/cli_config.dart' as cli_config;
 
 import 'config_exception.dart';
 
 /// YAML Reader which enables to override specific values from command line.
 class YamlReader {
-  YamlReader.of(this.cli, this.yaml, this.yamlFile);
-  Map<String, String> cli;
-  Map<dynamic, dynamic> yaml;
-  File? yamlFile;
+  final cli_config.Config _config;
+
+  final Uri? _configRoot;
+
+  YamlReader.of(this._config, this._configRoot);
 
   /// Parses the provided command line arguments and returns a [YamlReader].
   ///
@@ -42,19 +44,15 @@ class YamlReader {
       stderr.writeln(parser.usage);
       exit(1);
     }
-    final configFile = results['config'] as String?;
-    Map<dynamic, dynamic> yamlMap = {};
-    if (configFile != null) {
+    final configFilePath = results['config'] as String?;
+    String? configFileContents;
+    Uri? configFileUri;
+    if (configFilePath != null) {
       try {
-        final yamlInput = loadYaml(File(configFile).readAsStringSync(),
-            sourceUrl: Uri.file(configFile));
-        if (yamlInput is Map) {
-          yamlMap = yamlInput;
-        } else {
-          throw ConfigException('YAML config must be set of key value pairs');
-        }
+        configFileContents = File(configFilePath).readAsStringSync();
+        configFileUri = File(configFilePath).uri;
       } on Exception catch (e) {
-        stderr.writeln('cannot read $configFile: $e');
+        stderr.writeln('Cannot read $configFilePath: $e.');
       }
     }
     final regex = RegExp('([a-z-_.]+)=(.+)');
@@ -69,62 +67,45 @@ class YamlReader {
         throw ConfigException('override does not match expected pattern');
       }
     }
+    final config = cli_config.Config.fromConfigFileContents(
+      commandLineDefines: results['override'],
+      workingDirectory: Directory.current.uri,
+      environment: Platform.environment,
+      fileContents: configFileContents,
+      fileSourceUri: configFileUri,
+    );
     return YamlReader.of(
-        properties, yamlMap, configFile != null ? File(configFile) : null);
+      config,
+      configFileUri?.resolve('.'),
+    );
   }
 
-  bool? getBool(String property) {
-    if (cli.containsKey(property)) {
-      final v = cli[property]!;
-      if (v == 'true') {
-        return true;
-      }
-      if (v == 'false') {
-        return false;
-      }
-      throw ConfigException('expected boolean value for $property, got $v');
-    }
-    return getYamlValue<bool>(property);
-  }
+  bool? getBool(String property) => _config.optionalBool(property);
 
-  String? getString(String property) {
-    final configValue = cli[property] ?? getYamlValue<String>(property);
-    return configValue;
-  }
+  String? getString(String property) => _config.optionalString(property);
 
   /// Same as [getString] but path is resolved relative to YAML config if it's
   /// from YAML config.
-  String? getPath(String property) {
-    final cliOverride = cli[property];
-    if (cliOverride != null) return cliOverride;
-    final path = getYamlValue<String>(property);
-    if (path == null) return null;
-    // In (very unlikely) case YAML config didn't come from a file,
-    // do not try to resolve anything.
-    if (yamlFile == null) return path;
-    final yamlDir = yamlFile!.parent;
-    return yamlDir.uri.resolve(path).toFilePath();
-  }
+  String? getPath(String property) =>
+      _config.optionalPath(property)?.toFilePath();
 
-  List<String>? getStringList(String property) {
-    final configValue = cli[property]?.split(';') ??
-        getYamlValue<YamlList>(property)?.cast<String>();
-    return configValue;
-  }
+  List<String>? getStringList(String property) => _config.optionalStringList(
+        property,
+        splitCliPattern: ';',
+        combineAllConfigs: false,
+      );
 
   List<String>? getPathList(String property) {
-    final cliOverride = cli[property]?.split(';');
-    if (cliOverride != null) return cliOverride;
-    final paths = getYamlValue<YamlList>(property)?.cast<String>();
-    if (paths == null) return null;
-    // In (very unlikely) case YAML config didn't come from a file.
-    if (yamlFile == null) return paths;
-    final yamlDir = yamlFile!.parent;
-    return paths.map((path) => yamlDir.uri.resolve(path).toFilePath()).toList();
+    final configResult = _config.optionalPathList(
+      property,
+      combineAllConfigs: false,
+      splitCliPattern: ';',
+    );
+    return configResult?.map((e) => e.path).toList();
   }
 
   String? getOneOf(String property, Set<String> values) {
-    final value = cli[property] ?? getYamlValue<String>(property);
+    final value = _config.optionalString(property);
     if (value == null || values.contains(value)) {
       return value;
     }
@@ -132,34 +113,12 @@ class YamlReader {
   }
 
   Map<String, String>? getStringMap(String property) {
-    final value = getYamlValue<YamlMap>(property);
+    final value = _config.valueOf<YamlMap?>(property);
     return value?.cast<String, String>();
   }
 
-  bool hasValue(String property) => getYamlValue<dynamic>(property) != null;
-
-  T? getYamlValue<T>(String property) {
-    final path = property.split('.');
-    dynamic cursor = yaml;
-    String current = '';
-    for (var i in path) {
-      if (cursor is YamlMap || cursor is Map) {
-        cursor = cursor[i];
-      } else {
-        throw ConfigException('expected $current to be a YAML map');
-      }
-      current = [if (current != '') current, i].join('.');
-      if (cursor == null) {
-        return null;
-      }
-    }
-    if (cursor is! T) {
-      throw ConfigException(
-          'expected $T for $property, got ${cursor.runtimeType}');
-    }
-    return cursor;
-  }
+  bool hasValue(String property) => _config.valueOf<dynamic>(property) != null;
 
   /// Returns URI of the directory containing YAML config.
-  Uri? getConfigRoot() => yamlFile?.parent.uri;
+  Uri? getConfigRoot() => _configRoot;
 }

--- a/jnigen/pubspec.yaml
+++ b/jnigen/pubspec.yaml
@@ -2,16 +2,13 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-# DO NOT MERGE: prototype.
-publish_to: none
-
 name: jnigen
 version: 0.3.0
 description: Experimental generator for FFI+JNI bindings.
 repository: https://github.com/dart-lang/jnigen/tree/main/jnigen
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   json_annotation: ^4.8.0
@@ -20,11 +17,7 @@ dependencies:
   args: ^2.3.0
   yaml: ^3.1.0
   logging: ^1.0.2
-  cli_config:
-    git:
-      url: https://github.com/dart-lang/tools.git
-      ref: ba179b3ed963e31baa663a17b16f1b6a63ea5b31
-      path: pkgs/cli_config/
+  cli_config: ^0.1.0
 
 dev_dependencies:
   lints: ^2.0.0

--- a/jnigen/pubspec.yaml
+++ b/jnigen/pubspec.yaml
@@ -2,13 +2,16 @@
 # for details. All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
+# DO NOT MERGE: prototype.
+publish_to: none
+
 name: jnigen
 version: 0.3.0
 description: Experimental generator for FFI+JNI bindings.
 repository: https://github.com/dart-lang/jnigen/tree/main/jnigen
 
 environment:
-  sdk: '>=2.17.0 <4.0.0'
+  sdk: ">=2.17.0 <4.0.0"
 
 dependencies:
   json_annotation: ^4.8.0
@@ -17,6 +20,11 @@ dependencies:
   args: ^2.3.0
   yaml: ^3.1.0
   logging: ^1.0.2
+  cli_config:
+    git:
+      url: https://github.com/dart-lang/tools.git
+      ref: ba179b3ed963e31baa663a17b16f1b6a63ea5b31
+      path: pkgs/cli_config/
 
 dev_dependencies:
   lints: ^2.0.0
@@ -25,4 +33,3 @@ dev_dependencies:
   test: ^1.17.5
   build_runner: ^2.2.0
   json_serializable: ^6.6.0
-

--- a/jnigen/test/config_test.dart
+++ b/jnigen/test/config_test.dart
@@ -76,7 +76,7 @@ final jnigenYaml = join(jacksonCoreTests, 'jnigen.yaml');
 Config parseYamlConfig({List<String> overrides = const []}) =>
     Config.parseArgs(['--config', jnigenYaml, ...overrides]);
 
-void testForErrorChecking(
+void testForErrorChecking<T extends Exception>(
     {required String name,
     required List<String> overrides,
     dynamic Function(Config)? function}) {
@@ -88,7 +88,7 @@ void testForErrorChecking(
           function(config);
         }
       },
-      throwsA(isA<ConfigException>()),
+      throwsA(isA<T>()),
     );
   });
 }
@@ -106,19 +106,19 @@ void main() {
   });
 
   group('Test for config error checking', () {
-    testForErrorChecking(
+    testForErrorChecking<ConfigException>(
       name: 'Invalid bindings type',
       overrides: ['-Doutput.bindings_type=c_base'],
     );
-    testForErrorChecking(
+    testForErrorChecking<ConfigException>(
       name: 'Invalid output structure',
       overrides: ['-Doutput.dart.structure=singl_file'],
     );
-    testForErrorChecking(
+    testForErrorChecking<ConfigException>(
       name: 'Dart path not ending with /',
       overrides: ['-Doutput.dart.path=lib'],
     );
-    testForErrorChecking(
+    testForErrorChecking<FormatException>(
       name: 'Invalid log level',
       overrides: ['-Dlog_level=inf'],
     );

--- a/jnigen/test/config_test.dart
+++ b/jnigen/test/config_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:jnigen/src/config/config.dart';
 import 'package:test/test.dart';
 import 'package:path/path.dart' hide equals;
@@ -10,12 +12,12 @@ import 'package:path/path.dart' as path show equals;
 import 'jackson_core_test/generate.dart';
 
 const packageTests = 'test';
-final jacksonCoreTests = join(packageTests, 'jackson_core_test');
-final thirdParty = join(jacksonCoreTests, 'third_party');
-final lib = join(thirdParty, 'lib');
-final src = join(thirdParty, 'src');
-final testLib = join(thirdParty, 'test_', 'lib');
-final testSrc = join(thirdParty, 'test_', 'src');
+final jacksonCoreTests = absolute(packageTests, 'jackson_core_test');
+final thirdParty = absolute(jacksonCoreTests, 'third_party');
+final lib = absolute(thirdParty, 'lib');
+final src = absolute(thirdParty, 'src');
+final testLib = absolute(thirdParty, 'test_', 'lib');
+final testSrc = absolute(thirdParty, 'test_', 'src');
 
 /// Compares 2 [Config] objects using [expect] to give useful errors when
 /// two fields are not equal.
@@ -95,8 +97,8 @@ void main() {
   final config = Config.parseArgs([
     '--config',
     jnigenYaml,
-    '-Doutput.c.path=$testSrc/',
-    '-Doutput.dart.path=$testLib/',
+    '-Doutput.c.path=$testSrc${Platform.pathSeparator}',
+    '-Doutput.dart.path=$testLib${Platform.pathSeparator}',
   ]);
 
   test('compare configuration values', () {


### PR DESCRIPTION
This PR replaces the command-line defines and yaml parsing logic with `package:cli_config`.

Notable changes:

* All paths are automatically resolved to absolute `Uri`s by `package:cli_config`.

Changes not done:

* Required keys are not marked as required at the moment, it would changes the control flow of the config. We could do this in a follow up CL.

Pre-merge todos:

* [x] Publish version v0.1.0 of `package:cli_config` and depend on that in this PR.

## Original proposal

I have seen at least three locations in which we want to handle configs:

1. package:ffigen
1. package:jnigen
1. https://github.com/dart-lang/sdk/issues/50565

So I propose we add a `package:config` that will be opinionated about how to provide config via CLI defines, environment variables, and/or a config file (YAML/JSON). I've made a prototype for this package here:

* https://github.com/dcharkes/config

Some of the logic is taken from this package, thanks @mahesh-hegde !

This PR is a proof of concept to check that `package:config` would satisfy the needs of `package:jnigen`.

Do not merge yet, I would like to iterate on `package:config` before releasing an initial version.

Feedback welcome.

One inconsistency I found between package:ffigen and package:jnigen is whether yaml keys use underscores or dashes.

Some related issues:

* https://github.com/dart-lang/jnigen/issues/186
* https://github.com/dart-lang/ffigen/issues/520