### PR TITLE
Remove all NdkVersion constraints

### DIFF
--- a/jni/android/build.gradle
+++ b/jni/android/build.gradle
@@ -31,13 +31,6 @@ android {
     // to bump the version in their app.
     compileSdkVersion 31
 
-    // Bumping the plugin ndkVersion requires all clients of this plugin to bump
-    // the version in their app and to download a newer version of the NDK.
-    // Note(MaheshH) - Flutter seems to download minimum NDK of flutter when
-    // below line is commented out.
-    // How about leaving it?
-    // ndkVersion "21.1.6352462"
-
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {
         cmake {

--- a/jnigen/example/kotlin_plugin/android/build.gradle
+++ b/jnigen/example/kotlin_plugin/android/build.gradle
@@ -30,10 +30,6 @@ android {
     // to bump the version in their app.
     compileSdkVersion 31
 
-    // Bumping the plugin ndkVersion requires all clients of this plugin to bump
-    // the version in their app and to download a newer version of the NDK.
-    ndkVersion "21.1.6352462"
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }

--- a/jnigen/example/notification_plugin/android/build.gradle
+++ b/jnigen/example/notification_plugin/android/build.gradle
@@ -29,10 +29,6 @@ android {
     // to bump the version in their app.
     compileSdkVersion 31
 
-    // Bumping the plugin ndkVersion requires all clients of this plugin to bump
-    // the version in their app and to download a newer version of the NDK.
-    ndkVersion "21.1.6352462"
-
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {
         cmake {

--- a/jnigen/example/pdfbox_plugin/android/build.gradle
+++ b/jnigen/example/pdfbox_plugin/android/build.gradle
@@ -29,10 +29,6 @@ android {
     // to bump the version in their app.
     compileSdkVersion 31
 
-    // Bumping the plugin ndkVersion requires all clients of this plugin to bump
-    // the version in their app and to download a newer version of the NDK.
-    ndkVersion "21.1.6352462"
-
     // Invoke the shared CMake build with the Android Gradle Plugin.
     externalNativeBuild {
         cmake {


### PR DESCRIPTION
Removes all ndkVersion constraints in build.gradle files.

If this passes CI, this change has to be discussed with upstream.

### Motivation

The Android SDK makes the assumption that each small minor NDK version is different. so if you have 21.1.65557 (for sake of example) and project needs 21.1.65556, it will redownload the latter.

Look at the CI logs for [this windows job](https://github.com/dart-lang/jnigen/actions/runs/4364307098/jobs/7631474774?pr=197). It's downloading 3 NDKs!.

In a developer machine, each NDK takes multiple GBs of storage space. Additionally, it takes forever to download an NDK where I live.

We should strive to use a single NDK version whenever possible, and that should be the installed version.

### Concerns:

Does removing NDKVersion constraint everywhere, including the `jni` support library, cause errors on machine without an NDK installed already?

Ideally it should auto install whatever NDK flutter currently recommends.

cc: @dcharkes