### PR TITLE
Maven caching

### DIFF
--- a/jnigen/bin/download_maven_jars.dart
+++ b/jnigen/bin/download_maven_jars.dart
@@ -16,7 +16,7 @@ void main(List<String> args) async {
   if (mavenDownloads != null) {
     MavenTools.invalidateCacheRecords(
       jarDir: mavenDownloads.jarDir,
-      sourcesDir: mavenDownloads.sourceDir,
+      sourceDir: mavenDownloads.sourceDir,
     );
     await MavenTools.downloadMavenJars(
         MavenTools.deps(mavenDownloads.jarOnlyDeps + mavenDownloads.sourceDeps),

--- a/jnigen/bin/download_maven_jars.dart
+++ b/jnigen/bin/download_maven_jars.dart
@@ -14,6 +14,10 @@ void main(List<String> args) async {
   final config = Config.parseArgs(args);
   final mavenDownloads = config.mavenDownloads;
   if (mavenDownloads != null) {
+    MavenTools.invalidateCacheRecords(
+      jarDir: mavenDownloads.jarDir,
+      sourcesDir: mavenDownloads.sourceDir,
+    );
     await MavenTools.downloadMavenJars(
         MavenTools.deps(mavenDownloads.jarOnlyDeps + mavenDownloads.sourceDeps),
         mavenDownloads.jarDir);

--- a/jnigen/bin/download_maven_jars.dart
+++ b/jnigen/bin/download_maven_jars.dart
@@ -14,10 +14,12 @@ void main(List<String> args) async {
   final config = Config.parseArgs(args);
   final mavenDownloads = config.mavenDownloads;
   if (mavenDownloads != null) {
-    MavenTools.invalidateCacheRecords(
-      jarDir: mavenDownloads.jarDir,
-      sourceDir: mavenDownloads.sourceDir,
-    );
+    if (config.invalidateCaches) {
+      MavenTools.invalidateCacheRecords(
+        jarDir: mavenDownloads.jarDir,
+        sourceDir: mavenDownloads.sourceDir,
+      );
+    }
     await MavenTools.downloadMavenJars(
         MavenTools.deps(mavenDownloads.jarOnlyDeps + mavenDownloads.sourceDeps),
         mavenDownloads.jarDir);

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -241,6 +241,7 @@ class Config {
     this.importMap,
     this.androidSdkConfig,
     this.mavenDownloads,
+    this.invalidateCaches = false,
     this.summarizerOptions,
     this.logLevel = Level.INFO,
     this.dumpJsonTo,
@@ -304,6 +305,12 @@ class Config {
 
   /// Additional options for the summarizer component
   final SummarizerOptions? summarizerOptions;
+
+  /// Invalidate auxiliary caches (Eg: downloaded maven artifacts) during
+  /// this invocation.
+  ///
+  /// This can be only passed through command line.
+  final bool invalidateCaches;
 
   /// Directory containing the YAML configuration file, if any.
   Uri? get configRoot => _configRoot;
@@ -435,6 +442,7 @@ class Config {
               androidExample: prov.getString(_Props.androidExample),
             )
           : null,
+      invalidateCaches: prov.commandLineOnlyOptions.invalidateCaches,
       logLevel: logLevelFromString(
         prov.getOneOf(
           _Props.logLevel,

--- a/jnigen/lib/src/generate_bindings.dart
+++ b/jnigen/lib/src/generate_bindings.dart
@@ -40,7 +40,7 @@ Future<void> generateJniBindings(Config config) async {
     if (config.invalidateCaches) {
       MavenTools.invalidateCacheRecords(
         jarDir: mavenDl.jarDir,
-        sourcesDir: mavenDl.sourceDir,
+        sourceDir: mavenDl.sourceDir,
       );
     }
 

--- a/jnigen/lib/src/generate_bindings.dart
+++ b/jnigen/lib/src/generate_bindings.dart
@@ -37,6 +37,13 @@ Future<void> generateJniBindings(Config config) async {
   final extraJars = <Uri>[];
   final mavenDl = config.mavenDownloads;
   if (mavenDl != null) {
+    if (config.invalidateCaches) {
+      MavenTools.invalidateCacheRecords(
+        jarDir: mavenDl.jarDir,
+        sourcesDir: mavenDl.sourceDir,
+      );
+    }
+
     final sourcePath = mavenDl.sourceDir;
     await Directory(sourcePath).create(recursive: true);
     await MavenTools.downloadMavenSources(

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -86,6 +86,8 @@ class MavenTools {
   }
 
   /// Returns true if there is any file newer than [filename] in directoryPath.
+  ///
+  /// TODO(PR): Handle the case where files in the directory are deleted manually.
   static bool _isNewestFile(String directoryPath, String filename) {
     final dir = Directory(directoryPath);
     final referenceFile = File(join(directoryPath, filename));

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -81,8 +81,6 @@ class MavenDependencyCachingTools {
       final currentCache = record.readAsStringSync();
       if (currentCache == cacheRecord &&
           _isNewestFile(directoryPath, recordName)) {
-        log.info('Cached maven ${artifactType.name} dependencies found'
-            ' in $directoryPath');
         return true;
       } else {
         record.deleteSync();
@@ -102,6 +100,8 @@ class MavenDependencyCachingTools {
   ) async {
     final cacheRecord = computeCacheRecord(artifactType, deps);
     if (validateCache(targetDir, artifactType, cacheRecord)) {
+      log.info('Cached maven ${artifactType.name} dependencies found'
+          ' in $targetDir');
       return;
     }
     await downloaderCallback(deps, targetDir);

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -17,6 +17,16 @@ enum MavenArtifactType {
   sources,
 }
 
+/// In order to avoid invoking maven every time, jnigen writes a record of
+/// downloaded dependencies to the target folder, and uses that file to
+/// determine when re-invoking maven is needed. (Eg when dependencies change).
+///
+/// This is the version string used to indicate breaking changes in layout of
+/// cached / downloaded maven dependencies.
+///
+/// Increment this version to force invalidation.
+const _cacheVersion = 'jnigen-maven-cache-v1';
+
 const _cacheRecordNames = {
   MavenArtifactType.jar: 'jnigen_maven_jar_cache.json',
   MavenArtifactType.sources: 'jnigen_maven_src_cache.json',
@@ -28,6 +38,7 @@ class MavenDependencyCachingTools {
     List<MavenDependency> mavenDeps,
   ) {
     return jsonEncode({
+      'cacheVersion': _cacheVersion,
       'artifactType': artifactType.name.toString(),
       'dependencies': mavenDeps.map((e) => e.toString()).toList(),
     });

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -50,7 +50,7 @@ class MavenDependencyCachingTools {
   static bool _isNewestFile(String directoryPath, String filename) {
     final dir = Directory(directoryPath);
     final referenceFile = File(join(directoryPath, filename));
-    final referenceLastModified = referenceFile.lastModifiedSync();
+    final referenceLastModified = referenceFile.statSync().modified;
     final files = dir.listSync(recursive: true);
     for (final file in files) {
       if (file.statSync().modified.isAfter(referenceLastModified)) {

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -80,20 +80,11 @@ class MavenTools {
       {String javaVersion = '11'}) {
     final depDecls = <String>[];
     for (var dep in deps) {
-      final otherTags = StringBuffer();
-      for (var entry in dep.otherTags.entries) {
-        otherTags.write('''
-      <${entry.key}>
-        ${entry.value}
-      </${entry.key}>
-      ''');
-      }
       depDecls.add('''
       <dependency>
         <groupId>${dep.groupID}</groupId>
         <artifactId>${dep.artifactID}</artifactId>
         <version>${dep.version}</version>
-        ${otherTags.toString()}
       </dependency>''');
     }
     return '''
@@ -121,8 +112,7 @@ ${depDecls.join("\n")}
 
 /// Maven dependency with group ID, artifact ID, and version.
 class MavenDependency {
-  MavenDependency(this.groupID, this.artifactID, this.version,
-      {this.otherTags = const {}});
+  MavenDependency(this.groupID, this.artifactID, this.version);
   factory MavenDependency.fromString(String fullName) {
     final components = fullName.split(':');
     if (components.length != 3) {
@@ -131,5 +121,4 @@ class MavenDependency {
     return MavenDependency(components[0], components[1], components[2]);
   }
   String groupID, artifactID, version;
-  Map<String, String> otherTags;
 }

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -92,16 +92,18 @@ class MavenDependencyCachingTools {
 
   /// Runs [downloaderCallback] wrapped in cache record checks.
   static Future<void> downloadWithCaching(
-    String targetDir,
-    List<MavenDependency> deps,
-    MavenArtifactType artifactType,
-    Future<void> Function(List<MavenDependency> deps, String targetDir)
-        downloaderCallback,
-  ) async {
+      String targetDir,
+      List<MavenDependency> deps,
+      MavenArtifactType artifactType,
+      Future<void> Function(List<MavenDependency> deps, String targetDir)
+          downloaderCallback,
+      {bool logCacheHit = true}) async {
     final cacheRecord = computeCacheRecord(artifactType, deps);
     if (validateCache(targetDir, artifactType, cacheRecord)) {
-      log.info('Cached maven ${artifactType.name} dependencies found'
-          ' in $targetDir');
+      if (logCacheHit) {
+        log.info('Cached maven ${artifactType.name} dependencies found'
+            ' in $targetDir');
+      }
       return;
     }
     await downloaderCallback(deps, targetDir);

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -38,6 +38,30 @@ class MavenTools {
     return proc.exitCode;
   }
 
+  static void invalidateCacheRecords({String? jarDir, String? sourcesDir}) {
+    if (jarDir != null) {
+      _invalidateCacheRecord(jarDir, _MavenArtifactType.jar);
+    }
+    if (sourcesDir != null) {
+      _invalidateCacheRecord(sourcesDir, _MavenArtifactType.sources);
+    }
+  }
+
+  static void _invalidateCacheRecord(
+    String directoryPath,
+    _MavenArtifactType artifactType,
+  ) {
+    final recordFile = File(join(
+      directoryPath,
+      _cacheRecordNames[artifactType],
+    ));
+    if (recordFile.existsSync()) {
+      log.info('Invalidating caches for maven ${artifactType.name} '
+          'artifacts in $directoryPath');
+      recordFile.deleteSync();
+    }
+  }
+
   static String _computeCacheRecord(
     _MavenArtifactType artifactType,
     List<MavenDependency> mavenDeps,

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -269,5 +269,5 @@ class MavenDependency {
     return '$groupID:$artifactID:$version';
   }
 
-  String groupID, artifactID, version;
+  final String groupID, artifactID, version;
 }

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -120,5 +120,11 @@ class MavenDependency {
     }
     return MavenDependency(components[0], components[1], components[2]);
   }
+
+  @override
+  String toString() {
+    return '$groupID:$artifactID:$version';
+  }
+
   String groupID, artifactID, version;
 }

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -38,12 +38,12 @@ class MavenTools {
     return proc.exitCode;
   }
 
-  static void invalidateCacheRecords({String? jarDir, String? sourcesDir}) {
+  static void invalidateCacheRecords({String? jarDir, String? sourceDir}) {
     if (jarDir != null) {
       _invalidateCacheRecord(jarDir, _MavenArtifactType.jar);
     }
-    if (sourcesDir != null) {
-      _invalidateCacheRecord(sourcesDir, _MavenArtifactType.sources);
+    if (sourceDir != null) {
+      _invalidateCacheRecord(sourceDir, _MavenArtifactType.sources);
     }
   }
 

--- a/jnigen/lib/src/tools/tools.dart
+++ b/jnigen/lib/src/tools/tools.dart
@@ -3,5 +3,5 @@
 // BSD-style license that can be found in the LICENSE file.
 
 export 'android_sdk_tools.dart';
-export 'maven_tools.dart';
+export 'maven_tools.dart' hide MavenDependencyCachingTools;
 export 'build_summarizer.dart';

--- a/jnigen/test/config_test.dart
+++ b/jnigen/test/config_test.dart
@@ -55,6 +55,7 @@ void expectConfigsAreEqual(Config a, Config b) {
   } else {
     expect(ba, isNull, reason: "androidSdkConfig");
   }
+  expect(a.invalidateCaches, equals(b.invalidateCaches));
   final aso = a.summarizerOptions;
   final bso = b.summarizerOptions;
   if (aso != null) {
@@ -120,5 +121,14 @@ void main() {
       name: 'Invalid log level',
       overrides: ['-Dlog_level=inf'],
     );
+  });
+
+  test('check invalidate-caches flag is applied in final config', () {
+    final config = Config.parseArgs([
+      '--config',
+      jnigenYaml,
+      '--invalidate-caches',
+    ]);
+    expect(config.invalidateCaches, isTrue);
   });
 }

--- a/jnigen/test/kotlin_test/generated_files_test.dart
+++ b/jnigen/test/kotlin_test/generated_files_test.dart
@@ -10,13 +10,17 @@ import 'generate.dart';
 import '../test_util/test_util.dart';
 
 void main() async {
-  test("Generate and compare bindings for kotlin_test", () async {
-    await generateAndCompareBindings(
-      getConfig(),
-      join(testRoot, "lib", "kotlin.dart"),
-      join(testRoot, "src"),
-    );
-  }); // test if generated file == expected file
+  test(
+    "Generate and compare bindings for kotlin_test",
+    () async {
+      await generateAndCompareBindings(
+        getConfig(),
+        join(testRoot, "lib", "kotlin.dart"),
+        join(testRoot, "src"),
+      );
+    },
+    timeout: const Timeout.factor(1.5),
+  ); // test if generated file == expected file
   test("Generate and analyze bindings for kotlin_test - pure dart", () async {
     await generateAndAnalyzeBindings(
       getConfig(BindingsType.dartOnly),

--- a/jnigen/test/maven_caching_test.dart
+++ b/jnigen/test/maven_caching_test.dart
@@ -53,7 +53,7 @@ void main() {
     final deps = [jacksonDependency];
     const artifactType = MavenArtifactType.jar;
     final cacheRecord = CachingTools.computeCacheRecord(artifactType, deps);
-    final tempDir = currentDir.createTempSync("mvn_cache_test");
+    final tempDir = currentDir.createTempSync("mvn_cache_test_");
 
     String createTargetDir() {
       final target = tempDir.createTempSync("mvn_jar_");

--- a/jnigen/test/maven_caching_test.dart
+++ b/jnigen/test/maven_caching_test.dart
@@ -1,0 +1,117 @@
+// Copyright (c) 2022, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// End-to-end test confirming yaml config works as expected.
+
+import 'dart:io';
+
+import 'package:jnigen/src/tools/maven_tools.dart';
+import 'package:path/path.dart' hide equals;
+import 'package:test/test.dart';
+
+const jacksonCoordinates = 'com.fasterxml.jackson.core:jackson-core:2.13.4';
+const pdfBoxCoordinates = 'org.apache.pdfbox:pdfbox:2.0.26';
+
+const jarDir = 'mvn_jar';
+const srcDir = 'mvn_src';
+const testFileJar1 = 'TestFile1.jar';
+const testFileJar2 = 'TestFile2.jar';
+const testFileJava1 = 'TestFile1.java';
+const testFileJava2 = 'TestFile2.java';
+
+typedef CachingTools = MavenDependencyCachingTools;
+
+typedef FileAction = void Function(String path);
+
+final currentDir = Directory(".");
+
+void writeDummyJars(String targetDir) {
+  File(join(targetDir, testFileJar1)).writeAsStringSync("test file 1");
+  File(join(targetDir, testFileJar2)).writeAsStringSync("test file 2");
+}
+
+void main() {
+  // Most tests in this file do not actually invoke maven. They actually just
+  // write some random files to test directory. The implementation should not
+  // care about the type of files.
+
+  final jacksonDependency = MavenDependency.fromString(jacksonCoordinates);
+  final pdfBoxDependency = MavenDependency.fromString(pdfBoxCoordinates);
+
+  test("Test cache record format", () {
+    final computedRecord = CachingTools.computeCacheRecord(
+      MavenArtifactType.sources,
+      [jacksonDependency, pdfBoxDependency],
+    );
+    expect(computedRecord, contains(pdfBoxCoordinates));
+    expect(computedRecord, contains(jacksonCoordinates));
+    expect(computedRecord, contains(MavenArtifactType.sources.name));
+  });
+
+  group('Test maven jar caching', () {
+    final deps = [jacksonDependency];
+    const artifactType = MavenArtifactType.jar;
+    final cacheRecord = CachingTools.computeCacheRecord(artifactType, deps);
+    final tempDir = currentDir.createTempSync("mvn_cache_test");
+
+    String createTargetDir() {
+      final target = tempDir.createTempSync("mvn_jar_");
+      return target.path;
+    }
+
+    Future<void> downloadWithCaching(String targetDir) async {
+      await Directory(targetDir).create();
+      await CachingTools.downloadWithCaching(
+        targetDir,
+        [jacksonDependency],
+        MavenArtifactType.jar,
+        (deps, targetDir) async => writeDummyJars(targetDir),
+      );
+    }
+
+    test('Check invalidation with different set of deps', () async {
+      final targetDir = createTargetDir();
+      await downloadWithCaching(targetDir);
+      final validation1 =
+          CachingTools.validateCache(targetDir, artifactType, cacheRecord);
+      expect(validation1, isTrue, reason: 'Freshly written cache is invalid');
+
+      final differentCacheRecord = CachingTools.computeCacheRecord(
+        artifactType,
+        [jacksonDependency, pdfBoxDependency],
+      );
+      final validation2 = CachingTools.validateCache(
+          targetDir, artifactType, differentCacheRecord);
+      expect(validation2, isFalse,
+          reason: 'Cache considered valid with different dependency set');
+    });
+
+    Future<void> checkInvalidationAfterFileAction(FileAction action) async {
+      final targetDir = createTargetDir();
+      await downloadWithCaching(targetDir);
+      final validation1 =
+          CachingTools.validateCache(targetDir, artifactType, cacheRecord);
+      expect(validation1, isTrue, reason: 'Freshly written cache is invalid');
+      // Depending on resoultion of the last modified timestamp,
+      // we may need to pass some time to see the effect.
+      sleep(const Duration(seconds: 1, milliseconds: 100));
+      action(join(targetDir, testFileJar1));
+      final validation2 =
+          CachingTools.validateCache(targetDir, artifactType, cacheRecord);
+      expect(validation2, isFalse, reason: 'Stale cache is considered valid');
+    }
+
+    test('Check cache invalidation after file modification', () async {
+      await checkInvalidationAfterFileAction(
+        (path) => File(path).writeAsStringSync("Invalid"),
+      );
+    });
+
+    test('Check invalidation after file deletion', () async {
+      await checkInvalidationAfterFileAction((path) => File(path).deleteSync());
+    });
+
+    tearDownAll(() => tempDir.deleteSync(recursive: true));
+  });
+}

--- a/jnigen/test/maven_caching_test.dart
+++ b/jnigen/test/maven_caching_test.dart
@@ -67,6 +67,7 @@ void main() {
         [jacksonDependency],
         MavenArtifactType.jar,
         (deps, targetDir) async => writeDummyJars(targetDir),
+        logCacheHit: false, // Prevent user logs from being printed in test.
       );
     }
 


### PR DESCRIPTION
This introduces some basic caching of maven dependency download tasks. While maven local caches the dependencies, invoking maven itself can slow down `jnigen` significantly.

This PR implements a simple caching mechanism based on file `last modified` timestamps. We write a JSON file containing `maven_downloads` spec. If any file in target dir has changed, or the spec itself has changed, we reinvoke maven. Otherwise maven command is not invoked.

The cache record can be force-invalidated by passing `--invalidate-caches` on command line.

__Also, when we are at it: should we change default maven dependency download folder to somewhere in `.dart_tool`?__

closes: #92 

