### PR TITLE
Rethrow exception in gradle stub

### DIFF
--- a/jnigen/lib/src/tools/android_sdk_tools.dart
+++ b/jnigen/lib/src/tools/android_sdk_tools.dart
@@ -91,6 +91,7 @@ task $_gradleGetClasspathTaskName(type: Copy) {
     } catch (Exception e) {
       System.err.println("$_gradleCannotFindJars")
       System.err.println("$_leftOverStubWarning")
+      throw e
     }
   }
 }


### PR DESCRIPTION
If gradle fails to get JAR list it should fail with an exception, not just print the error. It should've been added in #231 but I forgot to push this change.