### PR TITLE
Bunch of small testsuite improvements

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -92,6 +92,8 @@ jobs:
       - name: Run summarizer tests
         run: mvn surefire:test
         working-directory: ./jnigen/java
+      - name: Build summarizer
+        run: dart run jnigen:setup
       - name: Run VM tests
         run: dart test --test-randomize-ordering-seed random
       - name: Install coverage
@@ -243,7 +245,10 @@ jobs:
       - name: build notification_plugin example APK
         run: flutter build apk --target-platform=android-arm64
         working-directory: ./jnigen/example/notification_plugin/example
-      - run: dart test --test-randomize-ordering-seed random
+      - name: Build summarizer
+        run: dart run jnigen:setup
+      - name: Run tests
+        run: dart test --test-randomize-ordering-seed random
 
   test_jni_macos_minimal:
     needs: [analyze_jni]

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -93,7 +93,7 @@ jobs:
         run: mvn surefire:test
         working-directory: ./jnigen/java
       - name: Run VM tests
-        run: dart test --platform vm
+        run: dart test --test-randomize-ordering-seed random
       - name: Install coverage
         run: dart pub global activate coverage
       - name: Collect coverage
@@ -243,7 +243,7 @@ jobs:
       - name: build notification_plugin example APK
         run: flutter build apk --target-platform=android-arm64
         working-directory: ./jnigen/example/notification_plugin/example
-      - run: dart test
+      - run: dart test --test-randomize-ordering-seed random
 
   test_jni_macos_minimal:
     needs: [analyze_jni]
@@ -290,7 +290,7 @@ jobs:
       - run: git config --global core.autocrlf true
       - run: dart pub get
       - run: dart run jnigen:setup
-      - run: dart test
+      - run: dart test --test-randomize-ordering-seed random
 
   build_jni_example_linux:
     runs-on: ubuntu-latest

--- a/jni/bin/setup.dart
+++ b/jni/bin/setup.dart
@@ -7,12 +7,13 @@ import 'dart:io';
 import 'package:args/args.dart';
 import 'package:package_config/package_config.dart';
 
-const ansiRed = '\x1b[31m';
-const ansiDefault = '\x1b[39;49m';
+import 'package:jni/src/build_util/build_util.dart';
 
 const jniNativeBuildDirective =
     '# jni_native_build (Build with jni:setup. Do not delete this line.)';
 
+// When changing this constant here, also change corresponding path in
+// test/test_util.
 const _defaultRelativeBuildPath = "build/jni_libs";
 
 const _buildPath = "build-path";
@@ -124,19 +125,6 @@ Future<Map<String, String>> findDependencySources() async {
     }
   }
   return sources;
-}
-
-/// Returns true if [artifact] does not exist, or any file in [sourceDir] is
-/// newer than [artifact].
-bool needsBuild(File artifact, Directory sourceDir) {
-  if (!artifact.existsSync()) return true;
-  final fileLastModified = artifact.lastModifiedSync();
-  for (final entry in sourceDir.listSync(recursive: true)) {
-    if (entry.statSync().modified.isAfter(fileLastModified)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 /// Returns the name of file built using sources in [cDir]

--- a/jni/lib/src/build_util/build_util.dart
+++ b/jni/lib/src/build_util/build_util.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2022, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+// Any shared build logic should be here. This way it can be reused across bin/,
+// tool/ and test/.
+
+import 'dart:io';
+
+const ansiRed = '\x1b[31m';
+const ansiDefault = '\x1b[39;49m';
+
+/// Returns true if [artifact] does not exist, or any file in [sourceDir] is
+/// newer than [artifact].
+bool needsBuild(File artifact, Directory sourceDir) {
+  if (!artifact.existsSync()) return true;
+  final fileLastModified = artifact.lastModifiedSync();
+  for (final entry in sourceDir.listSync(recursive: true)) {
+    if (entry.statSync().modified.isAfter(fileLastModified)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/jni/test/exception_test.dart
+++ b/jni/test/exception_test.dart
@@ -11,6 +11,7 @@ import 'test_util/test_util.dart';
 
 void main() {
   if (!Platform.isAndroid) {
+    checkDylibIsUpToDate();
     bool caught = false;
     try {
       // If library does not exist, a helpful exception should be thrown.

--- a/jni/test/global_env_test.dart
+++ b/jni/test/global_env_test.dart
@@ -26,11 +26,7 @@ void main() {
 
   if (!Platform.isAndroid) {
     checkDylibIsUpToDate();
-    try {
-      Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
-    } on JvmExistsException catch (_) {
-      // TODO(#51): Support destroying and reinstantiating JVM.
-    }
+    Jni.spawnIfNotExists(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
   }
   run(testRunner: test);
 }

--- a/jni/test/global_env_test.dart
+++ b/jni/test/global_env_test.dart
@@ -25,6 +25,7 @@ void main() {
   // You have to manually pass the path to the `dartjni` dynamic library.
 
   if (!Platform.isAndroid) {
+    checkDylibIsUpToDate();
     try {
       Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
     } on JvmExistsException catch (_) {

--- a/jni/test/jarray_test.dart
+++ b/jni/test/jarray_test.dart
@@ -13,11 +13,7 @@ void main() {
   // Don't forget to initialize JNI.
   if (!Platform.isAndroid) {
     checkDylibIsUpToDate();
-    try {
-      Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
-    } on JvmExistsException catch (_) {
-      // TODO(#51): Support destroying and reinstantiating JVM.
-    }
+    Jni.spawnIfNotExists(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
   }
   run(testRunner: test);
 }

--- a/jni/test/jarray_test.dart
+++ b/jni/test/jarray_test.dart
@@ -12,6 +12,7 @@ import 'test_util/test_util.dart';
 void main() {
   // Don't forget to initialize JNI.
   if (!Platform.isAndroid) {
+    checkDylibIsUpToDate();
     try {
       Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
     } on JvmExistsException catch (_) {

--- a/jni/test/jobject_test.dart
+++ b/jni/test/jobject_test.dart
@@ -17,6 +17,7 @@ const maxLongInJava = 9223372036854775807;
 void main() {
   // Don't forget to initialize JNI.
   if (!Platform.isAndroid) {
+    checkDylibIsUpToDate();
     try {
       Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
     } on JvmExistsException catch (_) {

--- a/jni/test/jobject_test.dart
+++ b/jni/test/jobject_test.dart
@@ -18,11 +18,7 @@ void main() {
   // Don't forget to initialize JNI.
   if (!Platform.isAndroid) {
     checkDylibIsUpToDate();
-    try {
-      Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
-    } on JvmExistsException catch (_) {
-      // TODO(#51): Support destroying and reinstantiating JVM.
-    }
+    Jni.spawnIfNotExists(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
   }
   run(testRunner: test);
 }

--- a/jni/test/test_util/test_util.dart
+++ b/jni/test/test_util/test_util.dart
@@ -15,7 +15,9 @@ typedef TestRunnerCallback = void Function(
 final currentDir = Directory.current.uri;
 final dllSuffix =
     Platform.isWindows ? "dll" : (Platform.isMacOS ? "dylib" : "so");
-final dllPath = currentDir.resolve("build/jni_libs/dartjni.$dllSuffix");
+final dllPrefix = Platform.isWindows ? '' : 'lib';
+final dllPath =
+    currentDir.resolve("build/jni_libs/${dllPrefix}dartjni.$dllSuffix");
 final srcPath = currentDir.resolve("src/");
 
 /// Fail if dartjni dll is stale.

--- a/jni/test/test_util/test_util.dart
+++ b/jni/test/test_util/test_util.dart
@@ -2,8 +2,35 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
+import 'package:jni/src/build_util/build_util.dart';
+
 typedef TestCaseCallback = void Function();
 typedef TestRunnerCallback = void Function(
   String description,
   TestCaseCallback test,
 );
+
+final currentDir = Directory.current.uri;
+final dllSuffix =
+    Platform.isWindows ? "dll" : (Platform.isMacOS ? "dylib" : "so");
+final dllPath = currentDir.resolve("build/jni_libs/dartjni.$dllSuffix");
+final srcPath = currentDir.resolve("src/");
+
+/// Fail if dartjni dll is stale.
+void checkDylibIsUpToDate() {
+  final dllFile = File.fromUri(dllPath);
+  if (needsBuild(File.fromUri(dllPath), Directory.fromUri(srcPath))) {
+    final cause = dllFile.existsSync()
+        ? 'not up-to-date with source modifications'
+        : 'not built';
+    var message = '\nFatal: dartjni.$dllSuffix is $cause. Please run '
+        '`dart run jni:setup` and try again.';
+    if (stderr.supportsAnsiEscapes) {
+      message = ansiRed + message + ansiDefault;
+    }
+    stderr.writeln(message);
+    exit(1);
+  }
+}

--- a/jni/test/type_test.dart
+++ b/jni/test/type_test.dart
@@ -206,11 +206,7 @@ class $FType extends JObjType<F> {
 void main() {
   if (!Platform.isAndroid) {
     checkDylibIsUpToDate();
-    try {
-      Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
-    } on JvmExistsException catch (_) {
-      // TODO(#51): Support destroying and reinstantiating JVM.
-    }
+    Jni.spawnIfNotExists(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
   }
   run(testRunner: test);
 }

--- a/jni/test/type_test.dart
+++ b/jni/test/type_test.dart
@@ -205,6 +205,7 @@ class $FType extends JObjType<F> {
 
 void main() {
   if (!Platform.isAndroid) {
+    checkDylibIsUpToDate();
     try {
       Jni.spawn(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
     } on JvmExistsException catch (_) {

--- a/jnigen/dart_test.yaml
+++ b/jnigen/dart_test.yaml
@@ -1,0 +1,12 @@
+## Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+## for details. All rights reserved. Use of this source code is governed by a
+## BSD-style license that can be found in the LICENSE file.
+
+## This file defines test groups for jnigen. This will be helpful to exclude
+## lengthy tests by using -x flag.
+
+tags:
+  large_test:
+    timeout: 2x
+  summarizer_test:
+    timeout: 1x

--- a/jnigen/test/bindings_test.dart
+++ b/jnigen/test/bindings_test.dart
@@ -97,6 +97,7 @@ Future<void> setupDylibsAndClasses() async {
 }
 
 void main() async {
+  await checkLocallyBuiltDependencies();
   setUpAll(setupDylibsAndClasses);
 
   test('static final fields', () {

--- a/jnigen/test/config_test.dart
+++ b/jnigen/test/config_test.dart
@@ -10,6 +10,7 @@ import 'package:path/path.dart' hide equals;
 import 'package:path/path.dart' as path show equals;
 
 import 'jackson_core_test/generate.dart';
+import 'test_util/test_util.dart';
 
 const packageTests = 'test';
 final jacksonCoreTests = absolute(packageTests, 'jackson_core_test');
@@ -93,7 +94,8 @@ void testForErrorChecking<T extends Exception>(
   });
 }
 
-void main() {
+void main() async {
+  await checkLocallyBuiltDependencies();
   final config = Config.parseArgs([
     '--config',
     jnigenYaml,

--- a/jnigen/test/dart_generator_test.dart
+++ b/jnigen/test/dart_generator_test.dart
@@ -5,7 +5,11 @@
 import 'package:jnigen/src/bindings/dart_generator.dart';
 import 'package:test/test.dart';
 
-void main() {
+import 'test_util/test_util.dart';
+
+void main() async {
+  await checkLocallyBuiltDependencies();
+
   test('OutsideInBuffer', () {
     final buffer = OutsideInBuffer();
     buffer.appendLeft('f(');

--- a/jnigen/test/jackson_core_test/generated_files_test.dart
+++ b/jnigen/test/jackson_core_test/generated_files_test.dart
@@ -11,7 +11,8 @@ import '../test_util/test_util.dart';
 import 'generate.dart';
 
 void main() async {
-  setUpAll(failIfSummarizerNotBuilt);
+  await checkLocallyBuiltDependencies();
+
   test("compare generated bindings for jackson_core", () async {
     final lib = join(thirdPartyDir, 'lib');
     final src = join(thirdPartyDir, 'src');

--- a/jnigen/test/jackson_core_test/generated_files_test.dart
+++ b/jnigen/test/jackson_core_test/generated_files_test.dart
@@ -24,14 +24,16 @@ void main() async {
       'not just required classes', () async {
     final config = getConfig(generateFullVersion: true);
     await generateAndAnalyzeBindings(config);
-  }, timeout: const Timeout(Duration(minutes: 2)));
+  }, timeout: const Timeout(Duration(minutes: 2)), tags: largeTestTag);
+
   test('generate and analyze bindings using ASM', () async {
     final config = getConfig(generateFullVersion: true, useAsm: true);
     await generateAndAnalyzeBindings(config);
-  }, timeout: const Timeout(Duration(minutes: 2)));
+  }, timeout: const Timeout(Duration(minutes: 2)), tags: largeTestTag);
+
   test('Generate and analyze pure dart bindings', () async {
     final config = getConfig(generateFullVersion: true);
     config.outputConfig.bindingsType = BindingsType.dartOnly;
     await generateAndAnalyzeBindings(config);
-  }, timeout: const Timeout.factor(2));
+  }, timeout: const Timeout.factor(2), tags: largeTestTag);
 }

--- a/jnigen/test/jackson_core_test/generated_files_test.dart
+++ b/jnigen/test/jackson_core_test/generated_files_test.dart
@@ -11,6 +11,7 @@ import '../test_util/test_util.dart';
 import 'generate.dart';
 
 void main() async {
+  setUpAll(failIfSummarizerNotBuilt);
   test("compare generated bindings for jackson_core", () async {
     final lib = join(thirdPartyDir, 'lib');
     final src = join(thirdPartyDir, 'src');

--- a/jnigen/test/kotlin_test/generated_files_test.dart
+++ b/jnigen/test/kotlin_test/generated_files_test.dart
@@ -10,6 +10,8 @@ import 'generate.dart';
 import '../test_util/test_util.dart';
 
 void main() async {
+  setUpAll(failIfSummarizerNotBuilt);
+
   test(
     "Generate and compare bindings for kotlin_test",
     () async {

--- a/jnigen/test/kotlin_test/generated_files_test.dart
+++ b/jnigen/test/kotlin_test/generated_files_test.dart
@@ -32,5 +32,6 @@ void main() async {
       );
     },
     timeout: const Timeout.factor(1.5),
-  ); // test if generated file == expected file
+    tags: largeTestTag,
+  );
 }

--- a/jnigen/test/kotlin_test/generated_files_test.dart
+++ b/jnigen/test/kotlin_test/generated_files_test.dart
@@ -10,8 +10,9 @@ import 'generate.dart';
 import '../test_util/test_util.dart';
 
 void main() async {
-  setUpAll(failIfSummarizerNotBuilt);
-
+  // This is not run in setupAll, because we want to exit with one line of
+  // error message, not throw a long exception.
+  await checkLocallyBuiltDependencies();
   test(
     "Generate and compare bindings for kotlin_test",
     () async {

--- a/jnigen/test/package_resolver_test.dart
+++ b/jnigen/test/package_resolver_test.dart
@@ -5,6 +5,8 @@
 import 'package:jnigen/src/bindings/resolver.dart';
 import 'package:test/test.dart';
 
+import 'test_util/test_util.dart';
+
 class ResolverTest {
   ResolverTest(this.binaryName, this.expectedImport, this.expectedName);
   String binaryName;
@@ -12,7 +14,8 @@ class ResolverTest {
   String expectedName;
 }
 
-void main() {
+void main() async {
+  await checkLocallyBuiltDependencies();
   final resolver = Resolver(
       importMap: {
         'org.apache.pdfbox': 'package:pdfbox/pdfbox.dart',

--- a/jnigen/test/regenerate_examples_test.dart
+++ b/jnigen/test/regenerate_examples_test.dart
@@ -45,6 +45,8 @@ void testExample(String exampleName, String dartOutput, String? cOutput) {
 }
 
 void main() {
+  setUpAll(failIfSummarizerNotBuilt);
+
   testExample(
     'in_app_java',
     join('lib', 'android_utils.dart'),

--- a/jnigen/test/regenerate_examples_test.dart
+++ b/jnigen/test/regenerate_examples_test.dart
@@ -44,9 +44,8 @@ void testExample(String exampleName, String dartOutput, String? cOutput) {
   });
 }
 
-void main() {
-  setUpAll(failIfSummarizerNotBuilt);
-
+void main() async {
+  await checkLocallyBuiltDependencies();
   testExample(
     'in_app_java',
     join('lib', 'android_utils.dart'),

--- a/jnigen/test/regenerate_examples_test.dart
+++ b/jnigen/test/regenerate_examples_test.dart
@@ -23,25 +23,33 @@ final kotlinPluginYaml = join(kotlinPlugin, 'jnigen.yaml');
 /// them to provided reference outputs.
 ///
 /// [dartOutput] and [cOutput] are relative paths from example project dir.
-void testExample(String exampleName, String dartOutput, String? cOutput) {
-  test('Generate and compare bindings for $exampleName',
-      timeout: const Timeout.factor(2), () async {
-    final examplePath = join('example', exampleName);
-    final configPath = join(examplePath, 'jnigen.yaml');
+///
+/// Pass [isLargeTest] as true if the test will take considerable time.
+void testExample(String exampleName, String dartOutput, String? cOutput,
+    {bool isLargeTest = false}) {
+  test(
+    'Generate and compare bindings for $exampleName',
+    timeout: const Timeout.factor(2),
+    () async {
+      final examplePath = join('example', exampleName);
+      final configPath = join(examplePath, 'jnigen.yaml');
 
-    final dartBindingsPath = join(examplePath, dartOutput);
-    String? cBindingsPath;
-    if (cOutput != null) {
-      cBindingsPath = join(examplePath, cOutput);
-    }
+      final dartBindingsPath = join(examplePath, dartOutput);
+      String? cBindingsPath;
+      if (cOutput != null) {
+        cBindingsPath = join(examplePath, cOutput);
+      }
 
-    final config = Config.parseArgs(['--config', configPath]);
-    try {
-      await generateAndCompareBindings(config, dartBindingsPath, cBindingsPath);
-    } on GradleException catch (_) {
-      stderr.writeln('Skip: $exampleName');
-    }
-  });
+      final config = Config.parseArgs(['--config', configPath]);
+      try {
+        await generateAndCompareBindings(
+            config, dartBindingsPath, cBindingsPath);
+      } on GradleException catch (_) {
+        stderr.writeln('Skip: $exampleName');
+      }
+    },
+    tags: isLargeTest ? largeTestTag : null,
+  );
 }
 
 void main() async {
@@ -50,16 +58,24 @@ void main() async {
     'in_app_java',
     join('lib', 'android_utils.dart'),
     join('src', 'android_utils'),
+    isLargeTest: true,
   );
-  testExample('pdfbox_plugin', join('lib', 'src', 'third_party'), 'src');
+  testExample(
+    'pdfbox_plugin',
+    join('lib', 'src', 'third_party'),
+    'src',
+    isLargeTest: false,
+  );
   testExample(
     'notification_plugin',
     join('lib', 'notifications.dart'),
     'src',
+    isLargeTest: true,
   );
   testExample(
     'kotlin_plugin',
     join('lib', 'kotlin_bindings.dart'),
     'src',
+    isLargeTest: true,
   );
 }

--- a/jnigen/test/simple_package_test/generated_files_test.dart
+++ b/jnigen/test/simple_package_test/generated_files_test.dart
@@ -10,6 +10,8 @@ import 'generate.dart';
 import '../test_util/test_util.dart';
 
 void main() async {
+  setUpAll(failIfSummarizerNotBuilt);
+
   test("Generate and compare bindings for simple_package", () async {
     await generateAndCompareBindings(
       getConfig(),

--- a/jnigen/test/simple_package_test/generated_files_test.dart
+++ b/jnigen/test/simple_package_test/generated_files_test.dart
@@ -10,7 +10,7 @@ import 'generate.dart';
 import '../test_util/test_util.dart';
 
 void main() async {
-  setUpAll(failIfSummarizerNotBuilt);
+  await checkLocallyBuiltDependencies();
 
   test("Generate and compare bindings for simple_package", () async {
     await generateAndCompareBindings(

--- a/jnigen/test/summary_generation_test.dart
+++ b/jnigen/test/summary_generation_test.dart
@@ -5,6 +5,8 @@
 // These tests validate summary generation in various scenarios.
 // Currently, no validation of the summary content itself is done.
 
+@Tags(['summarizer_test'])
+
 import 'dart:io';
 
 import 'package:jnigen/src/config/config.dart';

--- a/jnigen/test/summary_generation_test.dart
+++ b/jnigen/test/summary_generation_test.dart
@@ -107,9 +107,12 @@ Config getConfig({List<String>? sourcePath, List<String>? classPath}) {
   );
 }
 
-void main() {
+void main() async {
+  // Running this before setupAll, because we want to avoid teardownAll too
+  // if this fails.
+  await failIfSummarizerNotBuilt();
   late Directory tempDir;
-  setUpAll(() {
+  setUpAll(() async {
     tempDir = getTempDir("jnigen_summary_tests_");
   });
 

--- a/jnigen/test/summary_generation_test.dart
+++ b/jnigen/test/summary_generation_test.dart
@@ -108,9 +108,7 @@ Config getConfig({List<String>? sourcePath, List<String>? classPath}) {
 }
 
 void main() async {
-  // Running this before setupAll, because we want to avoid teardownAll too
-  // if this fails.
-  await failIfSummarizerNotBuilt();
+  await checkLocallyBuiltDependencies();
   late Directory tempDir;
   setUpAll(() async {
     tempDir = getTempDir("jnigen_summary_tests_");

--- a/jnigen/test/test_util/test_util.dart
+++ b/jnigen/test/test_util/test_util.dart
@@ -5,11 +5,12 @@
 import 'dart:io';
 
 import 'package:jnigen/jnigen.dart';
+import 'package:jnigen/src/util/find_package.dart';
 import 'package:path/path.dart' hide equals;
 import 'package:test/test.dart';
 import 'package:logging/logging.dart' show Level;
 
-import 'package:jnigen/src/logging/logging.dart' show printError, log;
+import 'package:jnigen/src/logging/logging.dart';
 
 final _currentDirectory = Directory(".");
 
@@ -126,4 +127,29 @@ Future<void> generateAndAnalyzeBindings(Config config) async {
   } finally {
     tempDir.deleteSync(recursive: true);
   }
+}
+
+final summarizerJar = join('.', '.dart_tool', 'jnigen', 'ApiSummarizer.jar');
+
+Future<void> failIfSummarizerNotBuilt() async {
+  final jarExists = await File(summarizerJar).exists();
+  if (!jarExists) {
+    stderr.writeln();
+    log.fatal('Please build summarizer by running '
+        '`dart run jnigen:setup` and try again');
+  }
+  final isJarStale = jarExists &&
+      await isPackageModifiedAfter(
+          'jnigen', await File(summarizerJar).lastModified(), 'java/');
+  if (isJarStale) {
+    stderr.writeln();
+    log.fatal('Summarizer is not rebuilt after recent changes. '
+        'Please run `dart run jnigen:setup and try again');
+  }
+}
+
+/// Verifies if locally built dependencies (currently `ApiSummarizer`)
+/// are up-to-date.
+Future<void> checkLocallyBuiltDependencies() async {
+  await failIfSummarizerNotBuilt();
 }

--- a/jnigen/test/test_util/test_util.dart
+++ b/jnigen/test/test_util/test_util.dart
@@ -144,7 +144,7 @@ Future<void> failIfSummarizerNotBuilt() async {
   if (isJarStale) {
     stderr.writeln();
     log.fatal('Summarizer is not rebuilt after recent changes. '
-        'Please run `dart run jnigen:setup and try again');
+        'Please run `dart run jnigen:setup` and try again.');
   }
 }
 

--- a/jnigen/test/test_util/test_util.dart
+++ b/jnigen/test/test_util/test_util.dart
@@ -14,6 +14,11 @@ import 'package:jnigen/src/logging/logging.dart';
 
 final _currentDirectory = Directory(".");
 
+// If changing these constants, grep for these values. In some places, test
+// package expects string literals.
+const largeTestTag = 'large_test';
+const summarizerTestTag = 'summarizer_test';
+
 Directory getTempDir(String prefix) {
   return _currentDirectory.createTempSync(prefix);
 }


### PR DESCRIPTION
The commit messages should list it all :)

If you don't like any of the change, I can usually revert that individual commit.

- closes: #255 
- closes: #247 
- half-completes: #248
    - After either speeding up the bottleneck in `bindings_test` or marking it as large test, I expect `dart test -x large_test,summarizer_test` to complete much faster than entire testsuite, which will be useful in dev.