### PR TITLE
Support Maven version 4

### DIFF
--- a/jnigen/java/README.md
+++ b/jnigen/java/README.md
@@ -8,7 +8,7 @@ It's currently used in `jnigen` to get the information of the Java API.
 ## Build
 When using it via `jnigen`, the `jnigen:setup` script will take care of building the jar in appropriate location.
 
-To build the jar manually, run `mvn assembly:assembly` in project root. The jar will be created in `target/` directory.
+To build the jar manually, run `mvn compile` in project root. To build the jar and run the tests as well, run `mvn test`. The jar will be created in `target/` directory.
 
 ## Command line
 ```

--- a/jnigen/java/pom.xml
+++ b/jnigen/java/pom.xml
@@ -54,7 +54,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>
-                    <descriptorId>jar-with-dependencies</descriptorId>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
                     <appendAssemblyId>false</appendAssemblyId>
                     <archive>
                         <manifest>

--- a/jnigen/java/pom.xml
+++ b/jnigen/java/pom.xml
@@ -44,7 +44,7 @@
     <build>
 		<directory>${buildDir}/target</directory>
         <finalName>ApiSummarizer</finalName>
-        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+        <pluginManagement><!-- Lock down plugins versions to avoid using Maven defaults -->
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>

--- a/jnigen/java/pom.xml
+++ b/jnigen/java/pom.xml
@@ -44,6 +44,22 @@
     <build>
 		<directory>${buildDir}/target</directory>
         <finalName>ApiSummarizer</finalName>
+        <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+            <plugins>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jnigen/java/pom.xml
+++ b/jnigen/java/pom.xml
@@ -68,7 +68,7 @@
                 <executions>
                     <execution>
                         <id>make-assembly</id>
-                        <phase>package</phase>
+                        <phase>compile</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>

--- a/jnigen/java/pom.xml
+++ b/jnigen/java/pom.xml
@@ -53,6 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.5.0</version>
                 <configuration>
                     <descriptorRefs>
                         <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/jnigen/java/pom.xml
+++ b/jnigen/java/pom.xml
@@ -65,6 +65,15 @@
                         </manifest>
                     </archive>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jnigen/lib/src/tools/build_summarizer.dart
+++ b/jnigen/lib/src/tools/build_summarizer.dart
@@ -33,7 +33,7 @@ Future<void> buildApiSummarizer() async {
     '--batch-mode',
     '--update-snapshots',
     '-f',
-    pom.toFilePath()
+    pom.toFilePath(),
   ];
   log.info('execute mvn ${mvnArgs.join(" ")}');
   try {

--- a/jnigen/lib/src/tools/build_summarizer.dart
+++ b/jnigen/lib/src/tools/build_summarizer.dart
@@ -29,11 +29,11 @@ Future<void> buildApiSummarizer() async {
   final pom = pkg.resolve('java/pom.xml');
   await Directory(toolPath).create(recursive: true);
   final mvnArgs = [
+    'package',
     '--batch-mode',
     '--update-snapshots',
     '-f',
-    pom.toFilePath(),
-    'assembly:assembly'
+    pom.toFilePath()
   ];
   log.info('execute mvn ${mvnArgs.join(" ")}');
   try {

--- a/jnigen/lib/src/tools/build_summarizer.dart
+++ b/jnigen/lib/src/tools/build_summarizer.dart
@@ -29,7 +29,7 @@ Future<void> buildApiSummarizer() async {
   final pom = pkg.resolve('java/pom.xml');
   await Directory(toolPath).create(recursive: true);
   final mvnArgs = [
-    'package',
+    'compile',
     '--batch-mode',
     '--update-snapshots',
     '-f',


### PR DESCRIPTION
Currently building ApiSummarizer.jar fails if the user is running Maven version 4.x.  This pull request resolves this issue.

Closes: #199 