### PR TITLE
Fix encoding bug

### DIFF
--- a/jni/example/integration_test/on_device_jni_test.dart
+++ b/jni/example/integration_test/on_device_jni_test.dart
@@ -9,6 +9,7 @@ import '../../test/exception_test.dart' as exception_test;
 import '../../test/jlist_test.dart' as jlist_test;
 import '../../test/jmap_test.dart' as jmap_test;
 import '../../test/jobject_test.dart' as jobject_test;
+import '../../test/jstring_test.dart' as jstring_test;
 import '../../test/jset_test.dart' as jset_test;
 import '../../test/jarray_test.dart' as jarray_test;
 import '../../test/boxed_test.dart' as boxed_test;
@@ -26,6 +27,7 @@ void main() {
     jlist_test.run,
     jmap_test.run,
     jobject_test.run,
+    jstring_test.run,
     jset_test.run,
     jarray_test.run,
     boxed_test.run,

--- a/jni/example/lib/main.dart
+++ b/jni/example/lib/main.dart
@@ -55,6 +55,12 @@ int uptime() {
   );
 }
 
+String backAndForth() {
+  final jstring = '🪓'.toJString();
+  final dartString = jstring.toDartString(deleteOriginal: true);
+  return dartString;
+}
+
 void quit() {
   JObject.fromRef(Jni.getCurrentActivity())
       .use((ac) => ac.callMethodByName<void>("finish", "()V", []));
@@ -94,6 +100,7 @@ void main() {
     if (Platform.isAndroid) ...[
       Example("Minutes of usage since reboot",
           () => (uptime() / (60 * 1000)).floor()),
+      Example("Back and forth string conversion", () => backAndForth()),
       Example(
           "Device name",
           () => Jni.retrieveStaticField<String>(

--- a/jni/lib/src/lang/jstring.dart
+++ b/jni/lib/src/lang/jstring.dart
@@ -73,9 +73,9 @@ class JString extends JObject {
       throw NullJStringException();
     }
     final length = Jni.env.GetStringLength(reference);
-    final chars = Jni.env.GetStringCritical(reference, nullptr);
+    final chars = Jni.env.GetStringChars(reference, nullptr);
     final result = chars.cast<Utf16>().toDartString(length: length);
-    Jni.env.ReleaseStringCritical(reference, chars);
+    Jni.env.ReleaseStringChars(reference, chars);
     if (deleteOriginal) {
       delete();
     }

--- a/jni/lib/src/lang/jstring.dart
+++ b/jni/lib/src/lang/jstring.dart
@@ -73,9 +73,9 @@ class JString extends JObject {
       throw NullJStringException();
     }
     final length = Jni.env.GetStringLength(reference);
-    final chars = Jni.env.GetStringChars(reference, nullptr);
+    final chars = Jni.env.GetStringCritical(reference, nullptr);
     final result = chars.cast<Utf16>().toDartString(length: length);
-    Jni.env.ReleaseStringChars(reference, chars);
+    Jni.env.ReleaseStringCritical(reference, chars);
     if (deleteOriginal) {
       delete();
     }

--- a/jni/lib/src/lang/jstring.dart
+++ b/jni/lib/src/lang/jstring.dart
@@ -49,8 +49,8 @@ class JString extends JObject {
   JString.fromRef(JStringPtr reference) : super.fromRef(reference);
 
   static JStringPtr _toJavaString(String s) => using((arena) {
-        final chars = s.toNativeUtf8(allocator: arena).cast<Char>();
-        final jstr = Jni.env.NewStringUTF(chars);
+        final chars = s.toNativeUtf16(allocator: arena).cast<Uint16>();
+        final jstr = Jni.env.NewString(chars, s.length);
         if (jstr == nullptr) {
           throw 'Fatal: cannot convert string to Java string: $s';
         }
@@ -72,9 +72,10 @@ class JString extends JObject {
     if (reference == nullptr) {
       throw NullJStringException();
     }
-    final chars = Jni.env.GetStringUTFChars(reference, nullptr);
-    final result = chars.cast<Utf8>().toDartString();
-    Jni.env.ReleaseStringUTFChars(reference, chars);
+    final length = Jni.env.GetStringLength(reference);
+    final chars = Jni.env.GetStringCritical(reference, nullptr);
+    final result = chars.cast<Utf16>().toDartString(length: length);
+    Jni.env.ReleaseStringCritical(reference, chars);
     if (deleteOriginal) {
       delete();
     }

--- a/jni/src/third_party/global_jni_env.c
+++ b/jni/src/third_party/global_jni_env.c
@@ -2181,10 +2181,6 @@ jthrowable globalEnv_ReleasePrimitiveArrayCritical(jarray array,
 JniPointerResult globalEnv_GetStringCritical(jstring str, jboolean* isCopy) {
   attach_thread();
   const jchar* _result = (*jniEnv)->GetStringCritical(jniEnv, str, isCopy);
-  jthrowable _exception = check_exception();
-  if (_exception != NULL) {
-    return (JniPointerResult){.value = NULL, .exception = _exception};
-  }
   return (JniPointerResult){.value = _result, .exception = NULL};
 }
 

--- a/jni/test/jobject_test.dart
+++ b/jni/test/jobject_test.dart
@@ -244,15 +244,6 @@ void run({required TestRunnerCallback testRunner}) {
     );
     expect(maxLong, equals(maxLongInJava));
   });
-
-  group('String tests', () {
-    test('#278 UTF-8 bug', () {
-      const dolphin = '🐬';
-      final utf8String = dolphin.toJString();
-      final dartString = utf8String.toDartString(deleteOriginal: true);
-      expect(dartString, dolphin);
-    });
-  });
 }
 
 void doSomeWorkInIsolate(Void? _) {

--- a/jni/test/jobject_test.dart
+++ b/jni/test/jobject_test.dart
@@ -244,6 +244,15 @@ void run({required TestRunnerCallback testRunner}) {
     );
     expect(maxLong, equals(maxLongInJava));
   });
+
+  group('String tests', () {
+    test('#278 UTF-8 bug', () {
+      const dolphin = '🐬';
+      final utf8String = dolphin.toJString();
+      final dartString = utf8String.toDartString(deleteOriginal: true);
+      expect(dartString, dolphin);
+    });
+  });
 }
 
 void doSomeWorkInIsolate(Void? _) {

--- a/jni/test/jstring_test.dart
+++ b/jni/test/jstring_test.dart
@@ -1,0 +1,44 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:jni/jni.dart';
+import 'package:test/test.dart';
+
+import 'test_util/test_util.dart';
+
+void main() {
+  // Don't forget to initialize JNI.
+  if (!Platform.isAndroid) {
+    checkDylibIsUpToDate();
+    Jni.spawnIfNotExists(dylibDir: "build/jni_libs", jvmOptions: ["-Xmx128m"]);
+  }
+  run(testRunner: test);
+}
+
+void testStringBackAndForth(String str) {
+  final utf8String = str.toJString();
+  final dartString = utf8String.toDartString(deleteOriginal: true);
+  expect(dartString, str);
+}
+
+void run({required TestRunnerCallback testRunner}) {
+  testRunner('Long string back-and-forth', () {
+    testStringBackAndForth('1' * 8096);
+  });
+
+  testRunner('#278 UTF-8 bug', () {
+    testStringBackAndForth('🐬');
+  });
+
+  testRunner('String containing null character', () {
+    final str = 'A${String.fromCharCode(0)}B';
+    testStringBackAndForth(str);
+  });
+
+  testRunner('Zero length string', () {
+    testStringBackAndForth('');
+  });
+}

--- a/jni/test/jstring_test.dart
+++ b/jni/test/jstring_test.dart
@@ -19,26 +19,28 @@ void main() {
 }
 
 void testStringBackAndForth(String str) {
-  final utf8String = str.toJString();
-  final dartString = utf8String.toDartString(deleteOriginal: true);
+  final jstring = str.toJString();
+  final dartString = jstring.toDartString(deleteOriginal: true);
   expect(dartString, str);
 }
 
 void run({required TestRunnerCallback testRunner}) {
-  testRunner('Long string back-and-forth', () {
-    testStringBackAndForth('1' * 8096);
-  });
+  group("String encoding tests", () {
+    testRunner('Long string back-and-forth', () {
+      testStringBackAndForth('1' * 8096);
+    });
 
-  testRunner('#278 UTF-8 bug', () {
-    testStringBackAndForth('🐬');
-  });
+    testRunner('#278 UTF-8 bug', () {
+      testStringBackAndForth('🐬');
+    });
 
-  testRunner('String containing null character', () {
-    final str = 'A${String.fromCharCode(0)}B';
-    testStringBackAndForth(str);
-  });
+    testRunner('String containing null character', () {
+      final str = 'A${String.fromCharCode(0)}B';
+      testStringBackAndForth(str);
+    });
 
-  testRunner('Zero length string', () {
-    testStringBackAndForth('');
+    testRunner('Zero length string', () {
+      testStringBackAndForth('');
+    });
   });
 }

--- a/jni/tool/wrapper_generators/generate_c_extensions.dart
+++ b/jni/tool/wrapper_generators/generate_c_extensions.dart
@@ -206,6 +206,7 @@ const constBufferReturningFunctions = {
 /// Methods which do not throw exceptions, and thus not need to be checked
 const _noCheckException = {
   'GetVersion',
+  'GetStringCritical',
   'ExceptionClear',
   'ExceptionDescribe',
 };


### PR DESCRIPTION
Use UTF-16 instead of UTF-8 in string methods.

closes #278

~GetStringCritical works on standalone but breaks on Android. I am still debugging the cause.~

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.
