### PR TITLE
Fix the integration tests.

### DIFF
--- a/jni/example/android/build.gradle
+++ b/jni/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/jni/lib/src/util/jlist.dart
+++ b/jni/lib/src/util/jlist.dart
@@ -112,8 +112,8 @@ class JList<$E extends JObject> extends JObject with ListMixin<$E> {
       .getMethodIDOf(_class.reference, r"add", r"(Ljava/lang/Object;)Z");
   @override
   void add($E element) {
-    Jni.accessors.callMethodWithArgs(
-        reference, _addId, JniCallType.voidType, [element.reference]).check();
+    Jni.accessors.callMethodWithArgs(reference, _addId, JniCallType.booleanType,
+        [element.reference]).check();
   }
 
   static final _collectionClass = Jni.findJClass("java/util/Collection");


### PR DESCRIPTION
closes dart-lang/native#625

@mahesh-hegde  It's interesting that the normal tests didn't fail with a wrong return type for `add` method.