### PR TITLE
Interop part 1

### DIFF
--- a/jni/lib/jni_symbols.yaml
+++ b/jni/lib/jni_symbols.yaml
@@ -1,0 +1,12 @@
+version: 1.0.0
+files:
+  'jni.dart':
+    'java.lang.Object':
+      name: JObject
+      type_class: JObjectType
+      super_count: 0
+    'java.lang.String':
+      name: JString
+      type_class: JStringType
+      super_count: 1
+

--- a/jnigen/CHANGELOG.md
+++ b/jnigen/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.5.0-dev.0
-* No JNIGen changes (yet), but keeping version in lockstep with `package:jni`.
+* **Breaking Change** ([#72](https://github.com/dart-lang/jnigen/issues/72)): Removed support for `importMap` in favor of the newly added interop mechanism with importing yaml files.
+* Strings now use UTF16.
 
 ## 0.4.0
 * **Breaking Change** ([#145](https://github.com/dart-lang/jnigen/issues/145)): Type arguments are now named instead of positional.

--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -333,7 +333,7 @@ class _ClassGenerator extends Visitor<ClassDecl, void> {
         .map((typeParam) => 'this.$typeParam,')
         .join(_newLine(depth: 2));
     final superClass = (node.classDecl.superclass!.type as DeclaredType);
-    final superTypeClassesCall = superClass.classDecl.superCount == 0
+    final superTypeClassesCall = superClass.classDecl.isObject()
         ? ''
         : superClass.params
             .accept(_TypeClassGenerator(resolver))
@@ -1331,7 +1331,7 @@ class _TypeVarLocator extends TypeVisitor<Map<String, List<OutsideInBuffer>>> {
 
   @override
   Map<String, List<OutsideInBuffer>> visitDeclaredType(DeclaredType node) {
-    if (node.classDecl.superCount == 0) {
+    if (node.classDecl.isObject()) {
       return {};
     }
     final offset = node.classDecl.allTypeParams.length - node.params.length;

--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -31,9 +31,6 @@ const _voidPointer = '$_ffi.Pointer<$_ffi.Void>';
 
 // Prefixes and suffixes
 const _typeParamPrefix = '\$';
-// TODO(#143): this is a temporary fix for the name collision.
-const _typeClassPrefix = '\$';
-const _typeClassSuffix = 'Type';
 
 // Misc.
 const _classRef = '_class.reference';
@@ -195,7 +192,12 @@ import "package:jni/jni.dart" as jni;
       if (cBased) {
         s.writeln(cInitCode);
       }
-      final classGenerator = _ClassGenerator(config, s);
+      final resolver = Resolver(
+        importedClasses: config.importedClasses,
+        currentClass: null, // Single file mode.
+        inputClassNames: node.decls.keys.toSet(),
+      );
+      final classGenerator = _ClassGenerator(config, s, resolver);
       for (final classDecl in node.decls.values) {
         classDecl.accept(classGenerator);
       }
@@ -249,11 +251,11 @@ import "package:jni/jni.dart" as jni;
         s.write('import "$initFilePath";');
       }
       final resolver = Resolver(
-        importMap: config.importMap ?? {},
+        importedClasses: config.importedClasses,
         currentClass: fileClassName,
         inputClassNames: node.decls.keys.toSet(),
       );
-      final classGenerator = _ClassGenerator(config, s, resolver: resolver);
+      final classGenerator = _ClassGenerator(config, s, resolver);
       for (final classDecl in classesInFile) {
         classDecl.accept(classGenerator);
       }
@@ -281,13 +283,13 @@ import "package:jni/jni.dart" as jni;
 class _ClassGenerator extends Visitor<ClassDecl, void> {
   final Config config;
   final StringSink s;
-  final Resolver? resolver;
+  final Resolver resolver;
 
   _ClassGenerator(
     this.config,
-    this.s, {
+    this.s,
     this.resolver,
-  });
+  );
 
   static const staticTypeGetter = 'type';
   static const instanceTypeGetter = '\$$staticTypeGetter';
@@ -331,7 +333,7 @@ class _ClassGenerator extends Visitor<ClassDecl, void> {
         .map((typeParam) => 'this.$typeParam,')
         .join(_newLine(depth: 2));
     final superClass = (node.classDecl.superclass!.type as DeclaredType);
-    final superTypeClassesCall = superClass.classDecl == ClassDecl.object
+    final superTypeClassesCall = superClass.classDecl.superCount == 0
         ? ''
         : superClass.params
             .accept(_TypeClassGenerator(resolver))
@@ -365,7 +367,7 @@ class $name$typeParamsDef extends $superName {
     // Static TypeClass getter
     s.writeln(
         '  /// The type which includes information such as the signature of this class.');
-    final typeClassName = '$_typeClassPrefix$name$_typeClassSuffix';
+    final typeClassName = node.typeClassName;
     if (typeParams.isEmpty) {
       s.writeln('static const $staticTypeGetter = $typeClassName();');
     } else {
@@ -527,7 +529,7 @@ class _TypeGenerator extends TypeVisitor<String> {
     }
 
     final typeParams = _encloseIfNotEmpty('<', allTypeParams.join(', '), '>');
-    final prefix = resolver?.resolvePrefix(node.classDecl.binaryName) ?? '';
+    final prefix = resolver?.resolvePrefix(node.classDecl) ?? '';
     return '$prefix${node.classDecl.finalName}$typeParams';
   }
 
@@ -563,7 +565,7 @@ class _TypeClass {
 /// Generates the type class.
 class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
   final bool isConst;
-  final Resolver? resolver;
+  final Resolver resolver;
 
   _TypeClassGenerator(this.resolver, {this.isConst = true});
 
@@ -573,19 +575,13 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
         node.type.accept(_TypeClassGenerator(resolver, isConst: false));
     final ifConst = innerTypeClass.canBeConst && isConst ? 'const ' : '';
     return _TypeClass(
-      '$ifConst$_jArray$_typeClassSuffix(${innerTypeClass.name})',
+      '$ifConst${_jArray}Type(${innerTypeClass.name})',
       innerTypeClass.canBeConst,
     );
   }
 
   @override
   _TypeClass visitDeclaredType(DeclaredType node) {
-    if (node.classDecl.binaryName == 'java.lang.Object' ||
-        node.classDecl.binaryName == 'java.lang.String') {
-      final ifConst = isConst ? 'const ' : '';
-      return _TypeClass(
-          '$ifConst$_jni.${node.classDecl.finalName}$_typeClassSuffix()', true);
-    }
     final allTypeParams = node.classDecl.allTypeParams
         .accept(const _TypeParamGenerator(withExtends: false))
         .toList();
@@ -596,7 +592,8 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
 
     // Can be const if all the type parameters are defined and each of them are
     // also const.
-    final canBeConst = definedTypeClasses.every((e) => e.canBeConst);
+    final canBeConst =
+        allTypeParams.isEmpty || definedTypeClasses.every((e) => e.canBeConst);
 
     // Replacing the declared ones. They come at the end.
     // The rest will be `JObjectType`.
@@ -607,7 +604,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
         List.filled(
           allTypeParams.length - node.params.length,
           // Adding const to subexpressions if the entire expression is not const.
-          '${canBeConst ? '' : 'const '}$_jObject$_typeClassSuffix()',
+          '${canBeConst ? '' : 'const '}${_jObject}Type()',
         ),
       );
       allTypeParams.replaceRange(
@@ -621,9 +618,9 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
 
     final args = allTypeParams.join(', ');
     final ifConst = isConst && canBeConst ? 'const ' : '';
-    final prefix = resolver?.resolvePrefix(node.classDecl.binaryName) ?? '';
+    final prefix = resolver.resolvePrefix(node.classDecl);
     return _TypeClass(
-      '$ifConst$prefix$_typeClassPrefix${node.classDecl.finalName}$_typeClassSuffix($args)',
+      '$ifConst$prefix${node.classDecl.typeClassName}($args)',
       canBeConst,
     );
   }
@@ -631,7 +628,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
   @override
   _TypeClass visitPrimitiveType(PrimitiveType node) {
     final ifConst = isConst ? 'const ' : '';
-    return _TypeClass('$ifConst$_jni.${node.jniType}$_typeClassSuffix()', true);
+    return _TypeClass('$ifConst$_jni.${node.jniType}Type()', true);
   }
 
   @override
@@ -648,7 +645,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
   @override
   _TypeClass visitNonPrimitiveType(ReferredType node) {
     final ifConst = isConst ? 'const ' : '';
-    return _TypeClass('$ifConst$_jObject$_typeClassSuffix()', true);
+    return _TypeClass('$ifConst${_jObject}Type()', true);
   }
 }
 
@@ -759,7 +756,7 @@ class _ToNativeSuffix extends TypeVisitor<String> {
 }
 
 class _FromNative extends TypeVisitor<String> {
-  final Resolver? resolver;
+  final Resolver resolver;
   final String value;
 
   const _FromNative(this.resolver, this.value);
@@ -778,7 +775,7 @@ class _FromNative extends TypeVisitor<String> {
 
 class _FieldGenerator extends Visitor<Field, void> {
   final Config config;
-  final Resolver? resolver;
+  final Resolver resolver;
   final StringSink s;
 
   const _FieldGenerator(this.config, this.resolver, this.s);
@@ -932,7 +929,7 @@ class _MethodTypeSig extends Visitor<Method, String> {
 /// Generates Dart bindings for Java methods.
 class _MethodGenerator extends Visitor<Method, void> {
   final Config config;
-  final Resolver? resolver;
+  final Resolver resolver;
   final StringSink s;
 
   const _MethodGenerator(this.config, this.resolver, this.s);
@@ -1181,7 +1178,7 @@ class _CtorTypeClassDef extends Visitor<TypeParam, String> {
 /// void bar(Foo foo) => ...
 /// ```
 class _ParamDef extends Visitor<Param, String> {
-  final Resolver? resolver;
+  final Resolver resolver;
 
   const _ParamDef(this.resolver);
 
@@ -1289,7 +1286,7 @@ class OutsideInBuffer {
 /// ((((a.$type as jni.JArrayType).elementType) as $JMapType).V) as jni.JObjType<$T>
 /// ```
 class _ParamTypeLocator extends Visitor<Param, Map<String, List<String>>> {
-  final Resolver? resolver;
+  final Resolver resolver;
 
   _ParamTypeLocator({required this.resolver});
 
@@ -1308,7 +1305,7 @@ class _ParamTypeLocator extends Visitor<Param, Map<String, List<String>>> {
 }
 
 class _TypeVarLocator extends TypeVisitor<Map<String, List<OutsideInBuffer>>> {
-  final Resolver? resolver;
+  final Resolver resolver;
 
   _TypeVarLocator({required this.resolver});
 
@@ -1334,14 +1331,13 @@ class _TypeVarLocator extends TypeVisitor<Map<String, List<OutsideInBuffer>>> {
 
   @override
   Map<String, List<OutsideInBuffer>> visitDeclaredType(DeclaredType node) {
-    if (node.classDecl == ClassDecl.object) {
+    if (node.classDecl.superCount == 0) {
       return {};
     }
     final offset = node.classDecl.allTypeParams.length - node.params.length;
     final result = <String, List<OutsideInBuffer>>{};
-    final prefix = resolver?.resolvePrefix(node.binaryName) ?? '';
-    final typeClass =
-        '$prefix$_typeClassPrefix${node.classDecl.finalName}$_typeClassSuffix';
+    final prefix = resolver.resolvePrefix(node.classDecl);
+    final typeClass = '$prefix${node.classDecl.typeClassName}';
     for (var i = 0; i < node.params.length; ++i) {
       final typeParam = node.classDecl.allTypeParams[i + offset].name;
       final exprs = node.params[i].accept(this);
@@ -1361,7 +1357,7 @@ class _TypeVarLocator extends TypeVisitor<Map<String, List<OutsideInBuffer>>> {
     final exprs = node.type.accept(this);
     for (final e in exprs.values.expand((i) => i)) {
       e.appendLeft('((');
-      e.prependRight(' as $_jArray$_typeClassSuffix).elementType as $_jType)');
+      e.prependRight(' as ${_jArray}Type).elementType as $_jType)');
     }
     return exprs;
   }

--- a/jnigen/lib/src/bindings/linker.dart
+++ b/jnigen/lib/src/bindings/linker.dart
@@ -9,9 +9,13 @@ import 'visitor.dart';
 
 typedef _Resolver = ClassDecl Function(String? binaryName);
 
-/// Creates and links [ClassDecl] objects from imported dependencies.
-/// Adds references from child elements back to their parent elements.
-/// Resolves Kotlin specific `asyncReturnType` for methods.
+/// A [Visitor] that adds the correct [ClassDecl] references from the
+/// string binary names.
+///
+/// It adds the following references:
+/// * Links [ClassDecl] objects from imported dependencies.
+/// * Adds references from child elements back to their parent elements.
+/// * Resolves Kotlin specific `asyncReturnType` for methods.
 class Linker extends Visitor<Classes, Future<void>> {
   Linker(this.config);
 
@@ -59,7 +63,7 @@ class Linker extends Visitor<Classes, Future<void>> {
     ClassDecl resolve(String? binaryName) {
       return config.importedClasses[binaryName] ??
           node.decls[binaryName] ??
-          resolve('java.lang.Object');
+          resolve(TypeUsage.object.name);
     }
 
     final classLinker = _ClassLinker(

--- a/jnigen/lib/src/bindings/renamer.dart
+++ b/jnigen/lib/src/bindings/renamer.dart
@@ -135,18 +135,13 @@ class Renamer implements Visitor<Classes, void> {
 
 class _ClassRenamer implements Visitor<ClassDecl, void> {
   final Config config;
+  final Set<ClassDecl> renamed;
   final Map<String, int> classNameCounts = {};
-  final Set<ClassDecl> renamed = {...ClassDecl.predefined.values};
-  final Map<ClassDecl, Map<String, int>> nameCounts = {
-    for (final predefined in ClassDecl.predefined.values) ...{
-      predefined: {..._definedSyms},
-    }
-  };
-  final Map<ClassDecl, Map<String, int>> methodNumsAfterRenaming = {};
+  final Map<ClassDecl, Map<String, int>> nameCounts = {};
 
   _ClassRenamer(
     this.config,
-  );
+  ) : renamed = {...config.importedClasses.values};
 
   /// Returns class name as useful in dart.
   ///
@@ -160,7 +155,7 @@ class _ClassRenamer implements Visitor<ClassDecl, void> {
     renamed.add(node);
 
     nameCounts[node] = {..._definedSyms};
-    methodNumsAfterRenaming[node] = {};
+    node.methodNumsAfterRenaming = {};
 
     final className = _getSimplifiedClassName(node.binaryName);
     node.uniqueName = _renameConflict(classNameCounts, className);
@@ -178,7 +173,6 @@ class _ClassRenamer implements Visitor<ClassDecl, void> {
     final methodRenamer = _MethodRenamer(
       config,
       nameCounts[node]!,
-      methodNumsAfterRenaming,
     );
     for (final method in node.methods) {
       method.accept(methodRenamer);
@@ -192,11 +186,10 @@ class _ClassRenamer implements Visitor<ClassDecl, void> {
 }
 
 class _MethodRenamer implements Visitor<Method, void> {
-  _MethodRenamer(this.config, this.nameCounts, this.methodNumsAfterRenaming);
+  _MethodRenamer(this.config, this.nameCounts);
 
   final Config config;
   final Map<String, int> nameCounts;
-  final Map<ClassDecl, Map<String, int>> methodNumsAfterRenaming;
 
   @override
   void visit(Method node) {
@@ -205,17 +198,17 @@ class _MethodRenamer implements Visitor<Method, void> {
     // If node is in super class, assign its number, overriding it.
     final superClass =
         (node.classDecl.superclass!.type as DeclaredType).classDecl;
-    final superNum = methodNumsAfterRenaming[superClass]?[sig];
+    final superNum = superClass.methodNumsAfterRenaming[sig];
     if (superNum != null) {
       // Don't rename if superNum == 0
       // Unless the node name is a keyword.
       final superNumText = superNum == 0 ? '' : '$superNum';
       final methodName = superNum == 0 ? _keywordRename(name) : name;
       node.finalName = '$methodName$superNumText';
-      methodNumsAfterRenaming[node.classDecl]?[sig] = superNum;
+      node.classDecl.methodNumsAfterRenaming[sig] = superNum;
     } else {
       node.finalName = _renameConflict(nameCounts, name);
-      methodNumsAfterRenaming[node.classDecl]?[sig] = nameCounts[name]! - 1;
+      node.classDecl.methodNumsAfterRenaming[sig] = nameCounts[name]! - 1;
     }
     log.fine(
         'Method ${node.classDecl.binaryName}#${node.name} is named ${node.finalName}');

--- a/jnigen/lib/src/bindings/renamer.dart
+++ b/jnigen/lib/src/bindings/renamer.dart
@@ -152,6 +152,7 @@ class _ClassRenamer implements Visitor<ClassDecl, void> {
   @override
   void visit(ClassDecl node) {
     if (renamed.contains(node)) return;
+    log.finest('Renaming ${node.binaryName}.');
     renamed.add(node);
 
     nameCounts[node] = {..._definedSyms};
@@ -165,11 +166,13 @@ class _ClassRenamer implements Visitor<ClassDecl, void> {
     final uniquifyName =
         config.outputConfig.dartConfig.structure == OutputStructure.singleFile;
     node.finalName = uniquifyName ? node.uniqueName : className;
+    // TODO(#143): $ at the beginning is a temporary fix for the name collision.
+    node.typeClassName = '\$${node.finalName}Type';
     log.fine('Class ${node.binaryName} is named ${node.finalName}');
 
     final superClass = (node.superclass!.type as DeclaredType).classDecl;
     superClass.accept(this);
-    nameCounts[node]!.addAll(nameCounts[superClass]!);
+    nameCounts[node]!.addAll(nameCounts[superClass] ?? {});
     final methodRenamer = _MethodRenamer(
       config,
       nameCounts[node]!,

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -461,15 +461,6 @@ class Config {
     final prov = YamlReader.parseArgs(args);
 
     final List<String> missingValues = [];
-    final List<String> errors = [];
-
-    T? satisfies<T>(T? value, String? Function(T?) predicate) {
-      final error = predicate(value);
-      if (error != null) {
-        errors.add(error);
-      }
-      return value;
-    }
 
     T must<T>(T? Function(String) f, T ifNull, String property) {
       final res = f(property);
@@ -524,8 +515,7 @@ class Config {
       summarizerOptions: SummarizerOptions(
         extraArgs: prov.getStringList(_Props.summarizerArgs) ?? const [],
         backend: prov.getString(_Props.backend),
-        workingDirectory:
-            satisfies(prov.getPath(_Props.summarizerWorkingDir), (p0) => null),
+        workingDirectory: prov.getPath(_Props.summarizerWorkingDir),
       ),
       exclude: BindingExclusions(
         methods: regexFilter<Method>(_Props.excludeMethods),

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -5,11 +5,19 @@
 import 'dart:io';
 
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
 
 import '../elements/elements.dart';
+import '../logging/logging.dart';
+import '../util/find_package.dart';
 import 'config_exception.dart';
 import 'filters.dart';
 import 'yaml_reader.dart';
+
+/// Modify this when symbols file format changes according to pub_semver.
+final _currentVersion = Version(1, 0, 0);
 
 /// Configuration for dependencies to be downloaded using maven.
 ///
@@ -209,9 +217,9 @@ class DartCodeOutputConfig {
     this.structure = OutputStructure.packageStructure,
   }) {
     if (structure == OutputStructure.singleFile) {
-      if (!path.toFilePath().endsWith('.dart')) {
+      if (p.extension(path.toFilePath()) != '.dart') {
         throw ConfigException(
-            'output path must end with ".dart" in single file mode');
+            'Dart\'s output path must end with ".dart" in single file mode.');
       }
     } else {
       _ensureIsDirectory('Dart output path', path);
@@ -225,19 +233,32 @@ class DartCodeOutputConfig {
   OutputStructure structure;
 }
 
+class SymbolsOutputConfig {
+  /// Path to write generated Dart bindings.
+  final Uri path;
+
+  SymbolsOutputConfig(this.path) {
+    if (p.extension(path.toFilePath()) != '.yaml') {
+      throw ConfigException('Symbol\'s output path must end with ".yaml".');
+    }
+  }
+}
+
 class OutputConfig {
   OutputConfig({
+    required this.dartConfig,
     this.bindingsType = BindingsType.cBased,
     this.cConfig,
-    required this.dartConfig,
+    this.symbolsConfig,
   }) {
     if (bindingsType == BindingsType.cBased && cConfig == null) {
-      throw ConfigException("C output config must be provided!");
+      throw ConfigException('C output config must be provided!');
     }
   }
   BindingsType bindingsType;
   DartCodeOutputConfig dartConfig;
   CCodeOutputConfig? cConfig;
+  SymbolsOutputConfig? symbolsConfig;
 }
 
 class BindingExclusions {
@@ -263,6 +284,7 @@ class Config {
     this.summarizerOptions,
     this.logLevel = Level.INFO,
     this.dumpJsonTo,
+    this.imports,
   });
 
   /// Output configuration for generated bindings
@@ -321,8 +343,113 @@ class Config {
   /// along with their transitive dependencies.
   final MavenDownloads? mavenDownloads;
 
-  /// Additional options for the summarizer component
+  /// Additional options for the summarizer component.
   final SummarizerOptions? summarizerOptions;
+
+  /// List of dependencies.
+  final List<Uri>? imports;
+
+  /// Call [importClasses] before using this.
+  late final Map<String, ClassDecl> importedClasses;
+
+  Future<void> importClasses() async {
+    importedClasses = {};
+    for (final import in [
+      // Implicitly importing package:jni symbols.
+      Uri.file('package:jni/jni_symbols.yaml'),
+      ...?imports,
+    ]) {
+      // Getting the actual uri in case of package uris.
+      final Uri yamlUri;
+      final String importPath;
+      if (import.scheme == 'package') {
+        final packageName = import.pathSegments.first;
+        final packageRoot = await findPackageRoot(packageName);
+        if (packageRoot == null) {
+          log.fatal('package:$packageName was not found.');
+        }
+        yamlUri = packageRoot
+            .resolve('lib/')
+            .resolve(import.pathSegments.sublist(1).join('/'));
+        importPath = 'package:$packageName';
+      } else {
+        yamlUri = import;
+        importPath = ([...import.pathSegments]..removeLast()).join('/');
+      }
+      final YamlMap yaml;
+      try {
+        final symbolsFile = File.fromUri(yamlUri);
+        final content = symbolsFile.readAsStringSync();
+        yaml = loadYaml(content, sourceUrl: yamlUri);
+      } on UnsupportedError catch (_) {
+        log.fatal('Could not reference "$import". Skipping.');
+      } catch (_) {
+        log.fatal('Error while parsing yaml file "$import". Skipping.');
+      }
+      final version = Version.parse(yaml['version'] as String);
+      if (!VersionConstraint.compatibleWith(_currentVersion).allows(version)) {
+        log.fatal('"$import" is version "$version" which is not compatible with'
+            'the current JNIgen symbols version $_currentVersion');
+      }
+      final files = yaml['files'] as YamlMap;
+      for (final entry in files.entries) {
+        final filePath = entry.key as String;
+        final classes = entry.value as YamlMap;
+        for (final classEntry in classes.entries) {
+          final binaryName = classEntry.key as String;
+          final decl = classEntry.value as YamlMap;
+          if (importedClasses.containsKey(binaryName)) {
+            log.fatal(
+              'Re-importing "$binaryName" in "$import".\n'
+              'Try hiding the class in import.',
+            );
+          }
+          final classDecl = ClassDecl(
+            simpleName: binaryName.split('.').last,
+            packageName: (binaryName.split('.')..removeLast()).join('.'),
+            binaryName: binaryName,
+          )
+            ..path = '$importPath/$filePath'
+            ..finalName = decl['name']
+            ..superCount = decl['super_count'];
+          for (final typeParamEntry
+              in (decl['type_params'] as YamlMap).entries) {
+            final typeParamName = typeParamEntry.key as String;
+            final bounds = (typeParamEntry.value as YamlMap).entries.map((e) {
+              final boundName = e.key as String;
+              // Can only be DECLARED or TYPE_VARIABLE
+              if (!['DECLARED', 'TYPE_VARIABLE'].contains(e.value)) {
+                log.fatal(
+                  'Unsupported bound kind "${e.value}" for bound "$boundName" '
+                  'in type parameter "$typeParamName" '
+                  'of "$binaryName".',
+                );
+              }
+              final boundKind = (e.value as String) == 'DECLARED'
+                  ? Kind.declared
+                  : Kind.typeVariable;
+              final ReferredType type;
+              if (boundKind == Kind.declared) {
+                type =
+                    DeclaredType(binaryName: boundName, simpleName: boundName);
+              } else {
+                type = TypeVar(name: boundName);
+              }
+              return TypeUsage(
+                  shorthand: boundName, kind: boundKind, typeJson: {})
+                ..type = type;
+            }).toList();
+            classDecl.allTypeParams.add(
+              TypeParam(name: typeParamName, bounds: bounds),
+            );
+          }
+          classDecl.methodNumsAfterRenaming =
+              (decl['methods'] as YamlMap).cast();
+          importedClasses[binaryName] = classDecl;
+        }
+      }
+    }
+  }
 
   /// Directory containing the YAML configuration file, if any.
   Uri? get configRoot => _configRoot;
@@ -337,13 +464,20 @@ class Config {
 
   static final _levels = Map.fromEntries(
       Level.LEVELS.map((l) => MapEntry(l.name.toLowerCase(), l)));
-  static List<Uri>? _toUris(List<String>? paths) =>
-      paths?.map(Uri.file).toList();
 
   static Config parseArgs(List<String> args) {
     final prov = YamlReader.parseArgs(args);
 
     final List<String> missingValues = [];
+    final List<String> errors = [];
+
+    T? satisfies<T>(T? value, String? Function(T?) predicate) {
+      final error = predicate(value);
+      if (error != null) {
+        errors.add(error);
+      }
+      return value;
+    }
 
     T must<T>(T? Function(String) f, T ifNull, String property) {
       final res = f(property);
@@ -353,9 +487,6 @@ class Config {
       }
       return res;
     }
-
-    Uri? directoryUri(String? path) =>
-        path != null ? Uri.directory(path) : null;
 
     MemberFilter<T>? regexFilter<T extends ClassMember>(String property) {
       final exclusions = prov.getStringList(property);
@@ -395,14 +526,14 @@ class Config {
         configRoot?.resolve(reference).toFilePath() ?? reference;
 
     final config = Config(
-      sourcePath: _toUris(prov.getPathList(_Props.sourcePath)),
-      classPath: _toUris(prov.getPathList(_Props.classPath)),
+      sourcePath: prov.getPathList(_Props.sourcePath),
+      classPath: prov.getPathList(_Props.classPath),
       classes: must(prov.getStringList, [], _Props.classes),
       summarizerOptions: SummarizerOptions(
         extraArgs: prov.getStringList(_Props.summarizerArgs) ?? const [],
         backend: prov.getString(_Props.backend),
         workingDirectory:
-            directoryUri(prov.getPath(_Props.summarizerWorkingDir)),
+            satisfies(prov.getPath(_Props.summarizerWorkingDir), (p0) => null),
       ),
       exclude: BindingExclusions(
         methods: regexFilter<Method>(_Props.excludeMethods),
@@ -417,27 +548,33 @@ class Config {
         cConfig: prov.hasValue(_Props.cCodeOutputConfig)
             ? CCodeOutputConfig(
                 libraryName: must(prov.getString, '', _Props.libraryName),
-                path: Uri.file(must(prov.getPath, '.', _Props.cRoot)),
+                path: must(prov.getPath, Uri.parse('.'), _Props.cRoot),
                 subdir: prov.getString(_Props.cSubdir),
               )
             : null,
         dartConfig: DartCodeOutputConfig(
-          path: Uri.file(must(prov.getPath, '.', _Props.dartRoot)),
+          path: must(prov.getPath, Uri.parse('.'), _Props.dartRoot),
           structure: getOutputStructure(
             prov.getString(_Props.outputStructure),
             OutputStructure.packageStructure,
           ),
         ),
+        symbolsConfig: prov.hasValue(_Props.symbolsOutputConfig)
+            ? SymbolsOutputConfig(
+                must(prov.getPath, Uri.parse('.'), _Props.symbolsOutputConfig),
+              )
+            : null,
       ),
       preamble: prov.getString(_Props.preamble),
       importMap: prov.getStringMap(_Props.importMap),
+      imports: prov.getPathList(_Props.import),
       mavenDownloads: prov.hasValue(_Props.mavenDownloads)
           ? MavenDownloads(
               sourceDeps: prov.getStringList(_Props.sourceDeps) ?? const [],
-              sourceDir: prov.getPath(_Props.mavenSourceDir) ??
+              sourceDir: prov.getPath(_Props.mavenSourceDir)?.toFilePath() ??
                   resolveFromConfigRoot(MavenDownloads.defaultMavenSourceDir),
               jarOnlyDeps: prov.getStringList(_Props.jarOnlyDeps) ?? const [],
-              jarDir: prov.getPath(_Props.mavenJarDir) ??
+              jarDir: prov.getPath(_Props.mavenJarDir)?.toFilePath() ??
                   resolveFromConfigRoot(MavenDownloads.defaultMavenJarDir),
             )
           : null,
@@ -497,10 +634,12 @@ class _Props {
   static const suspendFunToAsync = 'suspend_fun_to_async';
 
   static const importMap = 'import_map';
+  static const import = 'import';
   static const outputConfig = 'output';
   static const bindingsType = '$outputConfig.bindings_type';
   static const cCodeOutputConfig = '$outputConfig.c';
   static const dartCodeOutputConfig = '$outputConfig.dart';
+  static const symbolsOutputConfig = '$outputConfig.symbols';
   static const cRoot = '$cCodeOutputConfig.path';
   static const cSubdir = '$cCodeOutputConfig.subdir';
   static const dartRoot = '$dartCodeOutputConfig.path';

--- a/jnigen/lib/src/config/yaml_reader.dart
+++ b/jnigen/lib/src/config/yaml_reader.dart
@@ -86,8 +86,7 @@ class YamlReader {
 
   /// Same as [getString] but path is resolved relative to YAML config if it's
   /// from YAML config.
-  String? getPath(String property) =>
-      _config.optionalPath(property)?.toFilePath();
+  Uri? getPath(String property) => _config.optionalPath(property);
 
   List<String>? getStringList(String property) => _config.optionalStringList(
         property,
@@ -95,14 +94,11 @@ class YamlReader {
         combineAllConfigs: false,
       );
 
-  List<String>? getPathList(String property) {
-    final configResult = _config.optionalPathList(
-      property,
-      combineAllConfigs: false,
-      splitCliPattern: ';',
-    );
-    return configResult?.map((e) => e.path).toList();
-  }
+  List<Uri>? getPathList(String property) => _config.optionalPathList(
+        property,
+        combineAllConfigs: false,
+        splitCliPattern: ';',
+      );
 
   String? getOneOf(String property, Set<String> values) =>
       _config.optionalString(property, validValues: values);

--- a/jnigen/lib/src/elements/elements.dart
+++ b/jnigen/lib/src/elements/elements.dart
@@ -168,6 +168,8 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
 
   @override
   String get name => finalName;
+
+  bool isObject() => superCount == 0;
 }
 
 @JsonEnum()

--- a/jnigen/lib/src/elements/elements.dart
+++ b/jnigen/lib/src/elements/elements.dart
@@ -29,7 +29,7 @@ enum DeclKind {
 }
 
 class Classes implements Element<Classes> {
-  const Classes._(this.decls);
+  const Classes(this.decls);
 
   final Map<String, ClassDecl> decls;
 
@@ -39,7 +39,7 @@ class Classes implements Element<Classes> {
       final classDecl = ClassDecl.fromJson(declJson);
       decls[classDecl.binaryName] = classDecl;
     }
-    return Classes._(decls);
+    return Classes(decls);
   }
 
   @override
@@ -130,6 +130,18 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
   @JsonKey(includeFromJson: false)
   List<TypeParam> allTypeParams = const [];
 
+  /// The path which this class is generated in.
+  ///
+  /// Populated by [Linker].
+  @JsonKey(includeFromJson: false)
+  late final String path;
+
+  /// The numeric suffix of the methods.
+  ///
+  /// Populated by [Renamer].
+  @JsonKey(includeFromJson: false)
+  late final Map<String, int> methodNumsAfterRenaming;
+
   @override
   String toString() {
     return 'Java class declaration for $binaryName';
@@ -143,21 +155,8 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
     simpleName: 'Object',
   )
     ..finalName = 'JObject'
-    ..superCount = 0;
-
-  static final string = ClassDecl(
-    superclass: TypeUsage.object,
-    binaryName: 'java.lang.String',
-    packageName: 'java.lang',
-    simpleName: 'String',
-  )
-    ..finalName = 'JString'
-    ..superCount = 1;
-
-  static final predefined = {
-    'java.lang.Object': object,
-    'java.lang.String': string,
-  };
+    ..superCount = 0
+    ..path = 'package:jni/jni.dart';
 
   factory ClassDecl.fromJson(Map<String, dynamic> json) =>
       _$ClassDeclFromJson(json);

--- a/jnigen/lib/src/elements/elements.dart
+++ b/jnigen/lib/src/elements/elements.dart
@@ -115,6 +115,12 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
   @JsonKey(includeFromJson: false)
   late final String finalName;
 
+  /// Name of the type class.
+  ///
+  /// Populated by [Renamer].
+  @JsonKey(includeFromJson: false)
+  late final String typeClassName;
+
   /// Unique name obtained by renaming conflicting names with a number.
   ///
   /// This is used by C bindings instead of fully qualified name to reduce
@@ -148,15 +154,6 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
   }
 
   String get signature => 'L$internalName;';
-
-  static final object = ClassDecl(
-    binaryName: 'java.lang.Object',
-    packageName: 'java.lang',
-    simpleName: 'Object',
-  )
-    ..finalName = 'JObject'
-    ..superCount = 0
-    ..path = 'package:jni/jni.dart';
 
   factory ClassDecl.fromJson(Map<String, dynamic> json) =>
       _$ClassDeclFromJson(json);
@@ -195,15 +192,10 @@ class TypeUsage {
     required this.typeJson,
   });
 
-  static TypeUsage object = () {
-    final typeUsage = TypeUsage.fromJson({
-      "shorthand": "java.lang.Object",
-      "kind": "DECLARED",
-      "type": {"binaryName": "java.lang.Object", "simpleName": "Object"}
-    });
-    (typeUsage.type as DeclaredType).classDecl = ClassDecl.object;
-    return typeUsage;
-  }();
+  static TypeUsage object = TypeUsage(
+      kind: Kind.declared, shorthand: 'JObject', typeJson: {})
+    ..type =
+        (DeclaredType(binaryName: 'java.lang.Object', simpleName: 'Object'));
 
   final String shorthand;
   final Kind kind;

--- a/jnigen/lib/src/generate_bindings.dart
+++ b/jnigen/lib/src/generate_bindings.dart
@@ -34,10 +34,9 @@ Future<void> generateJniBindings(Config config) async {
     log.fatal(e.message);
   }
 
-  classes
-    ..accept(Excluder(config))
-    ..accept(Linker(config))
-    ..accept(Renamer(config));
+  classes.accept(Excluder(config));
+  await classes.accept(Linker(config));
+  classes.accept(Renamer(config));
 
   final cBased = config.outputConfig.bindingsType == BindingsType.cBased;
   if (cBased) {

--- a/jnigen/pubspec.yaml
+++ b/jnigen/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   json_annotation: ^4.8.0
   package_config: ^2.1.0
   path: ^1.8.0
+  pub_semver: ^2.1.4
   args: ^2.3.0
   yaml: ^3.1.0
   logging: ^1.0.2

--- a/jnigen/test/config_test.dart
+++ b/jnigen/test/config_test.dart
@@ -31,6 +31,9 @@ void expectConfigsAreEqual(Config a, Config b) {
       reason: "cRoot");
   expect(a.outputConfig.dartConfig.path, equals(b.outputConfig.dartConfig.path),
       reason: "dartRoot");
+  expect(a.outputConfig.symbolsConfig?.path,
+      equals(b.outputConfig.symbolsConfig?.path),
+      reason: "symbolsRoot");
   expect(a.sourcePath, equals(b.sourcePath), reason: "sourcePath");
   expect(a.classPath, equals(b.classPath), reason: "classPath");
   expect(a.preamble, equals(b.preamble), reason: "preamble");

--- a/jnigen/test/config_test.dart
+++ b/jnigen/test/config_test.dart
@@ -37,7 +37,6 @@ void expectConfigsAreEqual(Config a, Config b) {
   expect(a.sourcePath, equals(b.sourcePath), reason: "sourcePath");
   expect(a.classPath, equals(b.classPath), reason: "classPath");
   expect(a.preamble, equals(b.preamble), reason: "preamble");
-  expect(a.importMap, equals(b.importMap), reason: "importMap");
   final am = a.mavenDownloads;
   final bm = b.mavenDownloads;
   if (am != null) {

--- a/jnigen/test/package_resolver_test.dart
+++ b/jnigen/test/package_resolver_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:jnigen/src/bindings/resolver.dart';
+import 'package:jnigen/src/elements/elements.dart';
 import 'package:test/test.dart';
 
 import 'test_util/test_util.dart';
@@ -17,21 +18,28 @@ class ResolverTest {
 void main() async {
   await checkLocallyBuiltDependencies();
   final resolver = Resolver(
-      importMap: {
-        'org.apache.pdfbox': 'package:pdfbox/pdfbox.dart',
-        'android.os.Process': 'package:android/os.dart',
-      },
-      currentClass: 'a.b.N',
-      inputClassNames: {
-        'a.b.C',
-        'a.b.c.D',
-        'a.b.c.d.E',
-        'a.X',
-        'e.f.G',
-        'e.F',
-        'a.g.Y',
-        'a.m.n.P'
-      });
+    importedClasses: {
+      'org.apache.pdfbox.pdmodel.PDDocument': ClassDecl(
+        binaryName: 'org.apache.pdfbox.pdmodel.PDDocument',
+        simpleName: 'PDDocument',
+      )..path = 'package:pdfbox/pdfbox.dart',
+      'android.os.Process': ClassDecl(
+        binaryName: 'android.os.Process',
+        simpleName: 'Process',
+      )..path = 'package:android/os.dart',
+    },
+    currentClass: 'a.b.N',
+    inputClassNames: {
+      'a.b.C',
+      'a.b.c.D',
+      'a.b.c.d.E',
+      'a.X',
+      'e.f.G',
+      'e.F',
+      'a.g.Y',
+      'a.m.n.P'
+    },
+  );
 
   final tests = [
     // Absolute imports resolved using import map
@@ -64,6 +72,8 @@ void main() async {
     test(
         'resolve $binaryName',
         () => expect(
-            resolver.resolvePrefix(binaryName), equals(testCase.expectedName)));
+            resolver.resolvePrefix(
+                ClassDecl(binaryName: binaryName, simpleName: '')..path = ''),
+            equals(testCase.expectedName)));
   }
 }


### PR DESCRIPTION
I decided to make the PR in multiple parts for an easier review. This part only includes the importing (and not generating the `symbols.yaml` file). And it only imports `JString` and `JObject` and none of the newly added `JList`, `JSet`, etc. This way none of the generated bindings have been changed in this PR. 