### PR TITLE
remove simpleName and packageName

### DIFF
--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/AsmAnnotatedElementVisitor.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/AsmAnnotatedElementVisitor.java
@@ -17,7 +17,6 @@ public interface AsmAnnotatedElementVisitor {
     var annotation = new JavaAnnotation();
     var aType = Type.getType(descriptor);
     annotation.binaryName = aType.getClassName();
-    annotation.simpleName = TypeUtils.simpleName(aType);
     addAnnotation(annotation);
     return new AsmAnnotationVisitor(annotation);
   }

--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/AsmAnnotationVisitor.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/AsmAnnotationVisitor.java
@@ -35,7 +35,6 @@ public class AsmAnnotationVisitor extends AnnotationVisitor {
     var type = Type.getType(descriptor);
     var nested = new JavaAnnotation();
     nested.binaryName = type.getClassName();
-    nested.simpleName = TypeUtils.simpleName(type);
     annotation.properties.put(name, nested);
     return new AsmAnnotationVisitor(nested);
   }
@@ -71,7 +70,6 @@ public class AsmAnnotationVisitor extends AnnotationVisitor {
       var type = Type.getType(descriptor);
       var nested = new JavaAnnotation();
       nested.binaryName = type.getClassName();
-      nested.simpleName = TypeUtils.simpleName(type);
       list.add(nested);
       return new AsmAnnotationVisitor(nested);
     }

--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/AsmClassVisitor.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/AsmClassVisitor.java
@@ -48,9 +48,7 @@ public class AsmClassVisitor extends ClassVisitor implements AsmAnnotatedElement
     current.binaryName = type.getClassName();
     current.modifiers = TypeUtils.access(access);
     current.parentName = TypeUtils.parentName(type);
-    current.packageName = TypeUtils.packageName(type);
     current.declKind = TypeUtils.declKind(access);
-    current.simpleName = TypeUtils.simpleName(type);
     current.superclass = TypeUtils.typeUsage(Type.getObjectType(superName), null);
     current.interfaces =
         StreamUtil.map(interfaces, i -> TypeUtils.typeUsage(Type.getObjectType(i), null));

--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/TypeUtils.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/TypeUtils.java
@@ -23,15 +23,6 @@ class TypeUtils {
     return type.getClassName().split("\\$")[0];
   }
 
-  public static String packageName(Type type) {
-    var className = type.getClassName();
-    var last = className.lastIndexOf(".");
-    if (last != -1) {
-      return className.substring(0, last);
-    }
-    return null;
-  }
-
   public static String simpleName(Type type) {
     var internalName = type.getInternalName();
     if (type.getInternalName().length() == 1) {

--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/doclet/ElementBuilders.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/doclet/ElementBuilders.java
@@ -22,7 +22,6 @@ public class ElementBuilders {
 
   private void fillInFromTypeElement(TypeElement e, ClassDecl c) {
     c.modifiers = e.getModifiers().stream().map(Modifier::toString).collect(Collectors.toSet());
-    c.simpleName = e.getSimpleName().toString();
     c.binaryName = env.elements.getBinaryName(e).toString();
     switch (e.getKind()) {
       case INTERFACE:
@@ -45,7 +44,6 @@ public class ElementBuilders {
     if (parent instanceof TypeElement) {
       c.parentName = env.elements.getBinaryName((TypeElement) parent).toString();
     }
-    c.packageName = env.elements.getPackageOf(e).getQualifiedName().toString();
     c.javadoc = docComment(env.trees.getDocCommentTree(e));
     c.typeParams = StreamUtil.map(e.getTypeParameters(), this::typeParam);
     var superclass = e.getSuperclass();
@@ -82,7 +80,6 @@ public class ElementBuilders {
     var annotation = new JavaAnnotation();
     var type = mirror.getAnnotationType();
     var typeElement = (TypeElement) (env.types.asElement(type));
-    annotation.simpleName = typeElement.getSimpleName().toString();
     annotation.binaryName = env.elements.getBinaryName(typeElement).toString();
     var values = env.elements.getElementValuesWithDefaults(mirror);
     if (values.isEmpty()) {

--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/elements/ClassDecl.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/elements/ClassDecl.java
@@ -21,9 +21,6 @@ public class ClassDecl {
   /** Modifiers eg: static, public and abstract. */
   public Set<String> modifiers;
 
-  /** Unqualified name of the class. For example `ClassDecl` */
-  public String simpleName;
-
   /**
    * Unique, fully qualified name of the class, it's like a qualified name used in a program but
    * uses $ instead of dot (.) before nested classes.
@@ -31,7 +28,6 @@ public class ClassDecl {
   public String binaryName;
 
   public String parentName;
-  public String packageName;
   public List<TypeParam> typeParams = new ArrayList<>();
   public List<Method> methods = new ArrayList<>();
   public List<Field> fields = new ArrayList<>();

--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/elements/JavaAnnotation.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/elements/JavaAnnotation.java
@@ -8,7 +8,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class JavaAnnotation {
-  public String simpleName;
   public String binaryName;
   public Map<String, Object> properties = new HashMap<>();
 

--- a/jnigen/lib/src/bindings/c_generator.dart
+++ b/jnigen/lib/src/bindings/c_generator.dart
@@ -262,7 +262,6 @@ class _CMethodGenerator extends Visitor<Method, void> {
     if (node.isCtor) {
       javaReturnType = DeclaredType(
         binaryName: node.classDecl.binaryName,
-        simpleName: node.classDecl.simpleName,
       );
     }
     final callType = node.returnType.accept(const _CTypeCallSite());

--- a/jnigen/lib/src/bindings/linker.dart
+++ b/jnigen/lib/src/bindings/linker.dart
@@ -148,7 +148,7 @@ class _MethodLinker extends Visitor<Method, void> {
     if (config.suspendFunToAsync &&
         node.params.isNotEmpty &&
         node.params.last.type.kind == Kind.declared &&
-        node.params.last.type.shorthand == kotlinContinutationType) {
+        node.params.last.type.name == kotlinContinutationType) {
       final continuationType = node.params.last.type.type as DeclaredType;
       node.asyncReturnType = continuationType.params.isEmpty
           ? TypeUsage.object

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -395,8 +395,6 @@ class Config {
             );
           }
           final classDecl = ClassDecl(
-            simpleName: binaryName.split('.').last,
-            packageName: (binaryName.split('.')..removeLast()).join('.'),
             binaryName: binaryName,
           )
             ..path = '$importPath/$filePath'
@@ -423,14 +421,15 @@ class Config {
                   : Kind.typeVariable;
               final ReferredType type;
               if (boundKind == Kind.declared) {
-                type =
-                    DeclaredType(binaryName: boundName, simpleName: boundName);
+                type = DeclaredType(binaryName: boundName);
               } else {
                 type = TypeVar(name: boundName);
               }
               return TypeUsage(
-                  shorthand: boundName, kind: boundKind, typeJson: {})
-                ..type = type;
+                shorthand: binaryName,
+                kind: boundKind,
+                typeJson: {},
+              )..type = type;
             }).toList();
             classDecl.allTypeParams.add(
               TypeParam(name: typeParamName, bounds: bounds),

--- a/jnigen/lib/src/elements/elements.dart
+++ b/jnigen/lib/src/elements/elements.dart
@@ -58,9 +58,7 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
     this.annotations = const [],
     this.javadoc,
     this.modifiers = const {},
-    required this.simpleName,
     required this.binaryName,
-    this.packageName = '',
     this.parentName,
     this.typeParams = const [],
     this.methods = const [],
@@ -77,10 +75,8 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
 
   final List<Annotation> annotations;
   final JavaDocComment? javadoc;
-  final String simpleName;
   final String binaryName;
   final String? parentName;
-  final String packageName;
   List<TypeParam> typeParams;
   List<Method> methods;
   List<Field> fields;
@@ -96,6 +92,8 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
   final List<String>? values;
 
   String get internalName => binaryName.replaceAll(".", "/");
+
+  String get packageName => (binaryName.split('.')..removeLast()).join('.');
 
   /// The number of super classes this type has.
   ///
@@ -195,9 +193,8 @@ class TypeUsage {
   });
 
   static TypeUsage object = TypeUsage(
-      kind: Kind.declared, shorthand: 'JObject', typeJson: {})
-    ..type =
-        (DeclaredType(binaryName: 'java.lang.Object', simpleName: 'Object'));
+      kind: Kind.declared, shorthand: 'java.lang.Object', typeJson: {})
+    ..type = (DeclaredType(binaryName: 'java.lang.Object'));
 
   final String shorthand;
   final Kind kind;
@@ -356,12 +353,10 @@ class PrimitiveType extends ReferredType {
 class DeclaredType extends ReferredType {
   DeclaredType({
     required this.binaryName,
-    required this.simpleName,
     this.params = const [],
   });
 
   final String binaryName;
-  final String simpleName;
   final List<TypeUsage> params;
 
   @JsonKey(includeFromJson: false)
@@ -608,12 +603,10 @@ class JavaDocComment implements Element<JavaDocComment> {
 @JsonSerializable(createToJson: false)
 class Annotation implements Element<Annotation> {
   Annotation({
-    required this.simpleName,
     required this.binaryName,
     this.properties = const {},
   });
 
-  final String simpleName;
   final String binaryName;
   final Map<String, Object> properties;
 

--- a/jnigen/lib/src/elements/elements.dart
+++ b/jnigen/lib/src/elements/elements.dart
@@ -194,7 +194,7 @@ class TypeUsage {
 
   static TypeUsage object = TypeUsage(
       kind: Kind.declared, shorthand: 'java.lang.Object', typeJson: {})
-    ..type = (DeclaredType(binaryName: 'java.lang.Object'));
+    ..type = DeclaredType(binaryName: 'java.lang.Object');
 
   final String shorthand;
   final Kind kind;

--- a/jnigen/lib/src/elements/elements.g.dart
+++ b/jnigen/lib/src/elements/elements.g.dart
@@ -18,9 +18,7 @@ ClassDecl _$ClassDeclFromJson(Map<String, dynamic> json) => ClassDecl(
               ?.map((e) => e as String)
               .toSet() ??
           const {},
-      simpleName: json['simpleName'] as String,
       binaryName: json['binaryName'] as String,
-      packageName: json['packageName'] as String? ?? '',
       parentName: json['parentName'] as String?,
       typeParams: (json['typeParams'] as List<dynamic>?)
               ?.map((e) => TypeParam.fromJson(e as Map<String, dynamic>))
@@ -63,7 +61,6 @@ const _$KindEnumMap = {
 
 DeclaredType _$DeclaredTypeFromJson(Map<String, dynamic> json) => DeclaredType(
       binaryName: json['binaryName'] as String,
-      simpleName: json['simpleName'] as String,
       params: (json['params'] as List<dynamic>?)
               ?.map((e) => TypeUsage.fromJson(e as Map<String, dynamic>))
               .toList() ??
@@ -155,7 +152,6 @@ JavaDocComment _$JavaDocCommentFromJson(Map<String, dynamic> json) =>
     );
 
 Annotation _$AnnotationFromJson(Map<String, dynamic> json) => Annotation(
-      simpleName: json['simpleName'] as String,
       binaryName: json['binaryName'] as String,
       properties: (json['properties'] as Map<String, dynamic>?)?.map(
             (k, e) => MapEntry(k, e as Object),

--- a/jnigen/test/package_resolver_test.dart
+++ b/jnigen/test/package_resolver_test.dart
@@ -21,11 +21,9 @@ void main() async {
     importedClasses: {
       'org.apache.pdfbox.pdmodel.PDDocument': ClassDecl(
         binaryName: 'org.apache.pdfbox.pdmodel.PDDocument',
-        simpleName: 'PDDocument',
       )..path = 'package:pdfbox/pdfbox.dart',
       'android.os.Process': ClassDecl(
         binaryName: 'android.os.Process',
-        simpleName: 'Process',
       )..path = 'package:android/os.dart',
     },
     currentClass: 'a.b.N',
@@ -72,8 +70,8 @@ void main() async {
     test(
         'resolve $binaryName',
         () => expect(
-            resolver.resolvePrefix(
-                ClassDecl(binaryName: binaryName, simpleName: '')..path = ''),
+            resolver
+                .resolvePrefix(ClassDecl(binaryName: binaryName)..path = ''),
             equals(testCase.expectedName)));
   }
 }


### PR DESCRIPTION
These fields were not used in the code generation and it's trivial to reconstruct them from `binaryName`.

An example of what each of these are:
Binary: `some.package.SomeClass`
Simple: `SomeClass`
Package: `some.package`

Closes #284.