### PR TITLE
Non static nested class construction

### DIFF
--- a/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/TypeUtils.java
+++ b/jnigen/java/src/main/java/com/github/dart_lang/jnigen/apisummarizer/disasm/TypeUtils.java
@@ -20,7 +20,11 @@ import org.objectweb.asm.Type;
 class TypeUtils {
 
   public static String parentName(Type type) {
-    return type.getClassName().split("\\$")[0];
+    var className = type.getClassName();
+    if (!className.contains("$")) {
+      return null;
+    }
+    return className.split("\\$")[0];
   }
 
   public static String simpleName(Type type) {

--- a/jnigen/lib/src/bindings/c_generator.dart
+++ b/jnigen/lib/src/bindings/c_generator.dart
@@ -390,9 +390,12 @@ class _CParamGenerator extends Visitor<Param, String> {
   @override
   String visit(Param node) {
     final paramName =
-        _cTypeKeywords.contains(node.name) ? '${node.name}0' : node.name;
-    final type = node.type.accept(const _CReturnType());
-    if (addReturnType) return '$type $paramName';
+        (_cTypeKeywords.contains(node.name) ? '${node.name}0' : node.name)
+            .replaceAll('\$', '_');
+    if (addReturnType) {
+      final type = node.type.accept(const _CReturnType());
+      return '$type $paramName';
+    }
     return paramName;
   }
 }

--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -333,7 +333,7 @@ class _ClassGenerator extends Visitor<ClassDecl, void> {
         .map((typeParam) => 'this.$typeParam,')
         .join(_newLine(depth: 2));
     final superClass = (node.classDecl.superclass!.type as DeclaredType);
-    final superTypeClassesCall = superClass.classDecl.isObject()
+    final superTypeClassesCall = superClass.classDecl.isObject
         ? ''
         : superClass.params
             .accept(_TypeClassGenerator(resolver))
@@ -1331,7 +1331,7 @@ class _TypeVarLocator extends TypeVisitor<Map<String, List<OutsideInBuffer>>> {
 
   @override
   Map<String, List<OutsideInBuffer>> visitDeclaredType(DeclaredType node) {
-    if (node.classDecl.isObject()) {
+    if (node.classDecl.isObject) {
       return {};
     }
     final offset = node.classDecl.allTypeParams.length - node.params.length;

--- a/jnigen/lib/src/bindings/linker.dart
+++ b/jnigen/lib/src/bindings/linker.dart
@@ -92,8 +92,8 @@ class _ClassLinker extends Visitor<ClassDecl, void> {
     log.finest('Linking ${node.binaryName}.');
     _linked.add(node);
 
-    node.parent = resolve(node.parentName);
-    node.parent!.accept(this);
+    node.parent = node.parentName == null ? null : resolve(node.parentName);
+    node.parent?.accept(this);
     // Add type params of outer classes to the nested classes
     final allTypeParams = <TypeParam>[];
     if (!node.modifiers.contains('static')) {

--- a/jnigen/lib/src/bindings/linker.dart
+++ b/jnigen/lib/src/bindings/linker.dart
@@ -93,19 +93,6 @@ class _ClassLinker extends Visitor<ClassDecl, void> {
     _linked.add(node);
 
     node.parent = node.parentName == null ? null : resolve(node.parentName);
-    node.parent?.accept(this);
-    // Add type params of outer classes to the nested classes
-    final allTypeParams = <TypeParam>[];
-    if (!node.modifiers.contains('static')) {
-      for (final typeParam in node.parent!.allTypeParams) {
-        if (!node.allTypeParams.contains(typeParam)) {
-          // Add only if it's not shadowing another type param.
-          allTypeParams.add(typeParam);
-        }
-      }
-    }
-    allTypeParams.addAll(node.typeParams);
-    node.allTypeParams = allTypeParams;
 
     final typeLinker = _TypeLinker(resolve);
     node.superclass ??= TypeUsage.object;

--- a/jnigen/lib/src/bindings/renamer.dart
+++ b/jnigen/lib/src/bindings/renamer.dart
@@ -65,6 +65,7 @@ const Set<String> _keywords = {
   'throw',
   'true',
   'try',
+  'type', // Is used for type classes.
   'typedef',
   'var',
   'void',
@@ -213,8 +214,8 @@ class _MethodRenamer implements Visitor<Method, void> {
       node.finalName = _renameConflict(nameCounts, name);
       node.classDecl.methodNumsAfterRenaming[sig] = nameCounts[name]! - 1;
     }
-    log.fine(
-        'Method ${node.classDecl.binaryName}#${node.name} is named ${node.finalName}');
+    log.fine('Method ${node.classDecl.binaryName}#${node.name}'
+        ' is named ${node.finalName}');
 
     final paramRenamer = _ParamRenamer(config);
     for (final param in node.params) {
@@ -242,8 +243,8 @@ class _FieldRenamer implements Visitor<Field, void> {
       nameCounts,
       node.name,
     );
-    log.fine(
-        'Field ${node.classDecl.binaryName}#${node.name} is named ${node.finalName}');
+    log.fine('Field ${node.classDecl.binaryName}#${node.name}'
+        ' is named ${node.finalName}');
   }
 }
 

--- a/jnigen/lib/src/bindings/unnester.dart
+++ b/jnigen/lib/src/bindings/unnester.dart
@@ -1,0 +1,90 @@
+// Copyright (c) 2023, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../elements/elements.dart';
+import 'visitor.dart';
+
+/// A [Visitor] that processes nested classes.
+///
+/// Nested classes are not supported in Dart. So this "unnests" them into
+/// separate classes.
+class Unnester extends Visitor<Classes, void> {
+  @override
+  void visit(node) {
+    final classProcessor = _ClassUnnester();
+    for (final classDecl in node.decls.values) {
+      classDecl.accept(classProcessor);
+    }
+  }
+}
+
+class _ClassUnnester extends Visitor<ClassDecl, void> {
+  final processed = <ClassDecl>{};
+
+  @override
+  void visit(ClassDecl node) {
+    if (processed.contains(node)) return;
+    processed.add(node);
+    node.parent?.accept(this);
+
+    // Add type params of outer classes to the nested classes
+    final allTypeParams = <TypeParam>[];
+    if (!node.isStatic) {
+      for (final typeParam in node.parent?.allTypeParams ?? []) {
+        if (!node.allTypeParams.map((t) => t.name).contains(typeParam.name)) {
+          // Add only if it's not shadowing another type param.
+          allTypeParams.add(typeParam);
+        }
+      }
+    }
+    allTypeParams.addAll(node.typeParams);
+    node.allTypeParams = allTypeParams;
+
+    if (node.isNested && !node.isStatic) {
+      const methodProcessor = _MethodUnnester();
+      for (final method in node.methods) {
+        method.accept(methodProcessor);
+      }
+    }
+  }
+}
+
+class _MethodUnnester extends Visitor<Method, void> {
+  const _MethodUnnester();
+
+  @override
+  void visit(Method node) {
+    assert(!node.classDecl.isStatic);
+    assert(node.classDecl.isNested);
+    if (node.isCtor || node.isStatic) {
+      // Non-static nested classes take an instance of their outer class as the
+      // first parameter. This is not accounted for by the summarizer, so we
+      // manually add it as the first parameter.
+      final parentTypeParamCount = node.classDecl.allTypeParams.length -
+          node.classDecl.typeParams.length;
+      final parentTypeParams = node.classDecl.allTypeParams
+          .getRange(
+        0,
+        parentTypeParamCount,
+      )
+          .map((typeParam) {
+        final type = TypeVar(name: typeParam.name);
+        return TypeUsage(
+            shorthand: typeParam.name, kind: Kind.typeVariable, typeJson: {})
+          ..type = type;
+      }).toList();
+      final parentType = DeclaredType(
+        binaryName: node.classDecl.parent!.binaryName,
+        params: parentTypeParams,
+      )..classDecl = node.classDecl.parent!;
+      final parentTypeUsage = TypeUsage(
+          shorthand: parentType.binaryName, kind: Kind.declared, typeJson: {})
+        ..type = parentType;
+      final param = Param(name: '\$parent', type: parentTypeUsage);
+      // Make the list modifiable.
+      if (node.params.isEmpty) node.params = [];
+      node.params.insert(0, param);
+    }
+  }
+}

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -401,7 +401,8 @@ class Config {
             ..finalName = decl['name']
             ..typeClassName = decl['type_class']
             ..superCount = decl['super_count']
-            ..allTypeParams = [];
+            ..allTypeParams = []
+            ..parent = null;
           for (final typeParamEntry
               in ((decl['type_params'] as YamlMap?)?.entries) ??
                   <MapEntry<dynamic, dynamic>>[]) {

--- a/jnigen/lib/src/elements/elements.dart
+++ b/jnigen/lib/src/elements/elements.dart
@@ -167,7 +167,9 @@ class ClassDecl extends ClassMember implements Element<ClassDecl> {
   @override
   String get name => finalName;
 
-  bool isObject() => superCount == 0;
+  bool get isObject => superCount == 0;
+
+  bool get isNested => parentName != null;
 }
 
 @JsonEnum()
@@ -455,7 +457,7 @@ class Method extends ClassMember implements Element<Method> {
   final List<Annotation> annotations;
   final JavaDocComment? javadoc;
   final List<TypeParam> typeParams;
-  final List<Param> params;
+  List<Param> params;
   final TypeUsage returnType;
 
   /// The [ClassDecl] where this method is defined.

--- a/jnigen/lib/src/generate_bindings.dart
+++ b/jnigen/lib/src/generate_bindings.dart
@@ -9,6 +9,7 @@ import 'bindings/c_generator.dart';
 import 'bindings/dart_generator.dart';
 import 'bindings/excluder.dart';
 import 'bindings/linker.dart';
+import 'bindings/unnester.dart';
 import 'bindings/renamer.dart';
 import 'elements/elements.dart';
 import 'summary/summary.dart';
@@ -36,6 +37,7 @@ Future<void> generateJniBindings(Config config) async {
 
   classes.accept(Excluder(config));
   await classes.accept(Linker(config));
+  classes.accept(Unnester());
   classes.accept(Renamer(config));
 
   final cBased = config.outputConfig.bindingsType == BindingsType.cBased;

--- a/jnigen/test/simple_package_test/c_based/c_bindings/simple_package.c
+++ b/jnigen/test/simple_package_test/c_based/c_bindings/simple_package.c
@@ -1513,7 +1513,7 @@ jclass _c_GrandParent_Parent = NULL;
 
 jmethodID _m_GrandParent_Parent__ctor = NULL;
 FFI_PLUGIN_EXPORT
-JniResult GrandParent_Parent__ctor(jobject parentValue, jobject value) {
+JniResult GrandParent_Parent__ctor(jobject newValue) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent,
@@ -1521,13 +1521,44 @@ JniResult GrandParent_Parent__ctor(jobject parentValue, jobject value) {
   if (_c_GrandParent_Parent == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
   load_method(_c_GrandParent_Parent, &_m_GrandParent_Parent__ctor, "<init>",
-              "(Ljava/lang/Object;Ljava/lang/Object;)V");
+              "(Ljava/lang/Object;)V");
   if (_m_GrandParent_Parent__ctor == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  jobject _result =
-      (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent,
-                           _m_GrandParent_Parent__ctor, parentValue, value);
+  jobject _result = (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent,
+                                         _m_GrandParent_Parent__ctor, newValue);
   return to_global_ref_result(_result);
+}
+
+jfieldID _f_GrandParent_Parent__grandParentValue = NULL;
+FFI_PLUGIN_EXPORT
+JniResult get_GrandParent_Parent__grandParentValue(jobject self_) {
+  load_env();
+  load_class_global_ref(
+      &_c_GrandParent_Parent,
+      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
+  if (_c_GrandParent_Parent == NULL)
+    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
+  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__grandParentValue,
+             "grandParentValue", "Ljava/lang/Object;");
+  jobject _result = (*jniEnv)->GetObjectField(
+      jniEnv, self_, _f_GrandParent_Parent__grandParentValue);
+  return to_global_ref_result(_result);
+}
+
+FFI_PLUGIN_EXPORT
+JniResult set_GrandParent_Parent__grandParentValue(jobject self_,
+                                                   jobject value) {
+  load_env();
+  load_class_global_ref(
+      &_c_GrandParent_Parent,
+      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
+  if (_c_GrandParent_Parent == NULL)
+    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
+  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__grandParentValue,
+             "grandParentValue", "Ljava/lang/Object;");
+  (*jniEnv)->SetObjectField(jniEnv, self_,
+                            _f_GrandParent_Parent__grandParentValue, value);
+  return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 
 jfieldID _f_GrandParent_Parent__parentValue = NULL;
@@ -1561,44 +1592,12 @@ JniResult set_GrandParent_Parent__parentValue(jobject self_, jobject value) {
   return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 
-jfieldID _f_GrandParent_Parent__value = NULL;
-FFI_PLUGIN_EXPORT
-JniResult get_GrandParent_Parent__value(jobject self_) {
-  load_env();
-  load_class_global_ref(
-      &_c_GrandParent_Parent,
-      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
-  if (_c_GrandParent_Parent == NULL)
-    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__value, "value",
-             "Ljava/lang/Object;");
-  jobject _result =
-      (*jniEnv)->GetObjectField(jniEnv, self_, _f_GrandParent_Parent__value);
-  return to_global_ref_result(_result);
-}
-
-FFI_PLUGIN_EXPORT
-JniResult set_GrandParent_Parent__value(jobject self_, jobject value) {
-  load_env();
-  load_class_global_ref(
-      &_c_GrandParent_Parent,
-      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
-  if (_c_GrandParent_Parent == NULL)
-    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__value, "value",
-             "Ljava/lang/Object;");
-  (*jniEnv)->SetObjectField(jniEnv, self_, _f_GrandParent_Parent__value, value);
-  return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-}
-
 // com.github.dart_lang.jnigen.generics.GrandParent$Parent$Child
 jclass _c_GrandParent_Parent_Child = NULL;
 
 jmethodID _m_GrandParent_Parent_Child__ctor = NULL;
 FFI_PLUGIN_EXPORT
-JniResult GrandParent_Parent_Child__ctor(jobject grandParentValue,
-                                         jobject parentValue,
-                                         jobject value) {
+JniResult GrandParent_Parent_Child__ctor(jobject newValue) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent_Child,
@@ -1606,13 +1605,12 @@ JniResult GrandParent_Parent_Child__ctor(jobject grandParentValue,
   if (_c_GrandParent_Parent_Child == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
   load_method(_c_GrandParent_Parent_Child, &_m_GrandParent_Parent_Child__ctor,
-              "<init>",
-              "(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V");
+              "<init>", "(Ljava/lang/Object;)V");
   if (_m_GrandParent_Parent_Child__ctor == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  jobject _result = (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent_Child,
-                                         _m_GrandParent_Parent_Child__ctor,
-                                         grandParentValue, parentValue, value);
+  jobject _result =
+      (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent_Child,
+                           _m_GrandParent_Parent_Child__ctor, newValue);
   return to_global_ref_result(_result);
 }
 
@@ -1684,34 +1682,37 @@ JniResult set_GrandParent_Parent_Child__parentValue(jobject self_,
   return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 
-jfieldID _f_GrandParent_Parent_Child__value = NULL;
+jfieldID _f_GrandParent_Parent_Child__childValue = NULL;
 FFI_PLUGIN_EXPORT
-JniResult get_GrandParent_Parent_Child__value(jobject self_) {
+JniResult get_GrandParent_Parent_Child__childValue(jobject self_) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent_Child,
       "com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child");
   if (_c_GrandParent_Parent_Child == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent_Child, &_f_GrandParent_Parent_Child__value,
-             "value", "Ljava/lang/Object;");
+  load_field(_c_GrandParent_Parent_Child,
+             &_f_GrandParent_Parent_Child__childValue, "childValue",
+             "Ljava/lang/Object;");
   jobject _result = (*jniEnv)->GetObjectField(
-      jniEnv, self_, _f_GrandParent_Parent_Child__value);
+      jniEnv, self_, _f_GrandParent_Parent_Child__childValue);
   return to_global_ref_result(_result);
 }
 
 FFI_PLUGIN_EXPORT
-JniResult set_GrandParent_Parent_Child__value(jobject self_, jobject value) {
+JniResult set_GrandParent_Parent_Child__childValue(jobject self_,
+                                                   jobject value) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent_Child,
       "com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child");
   if (_c_GrandParent_Parent_Child == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent_Child, &_f_GrandParent_Parent_Child__value,
-             "value", "Ljava/lang/Object;");
-  (*jniEnv)->SetObjectField(jniEnv, self_, _f_GrandParent_Parent_Child__value,
-                            value);
+  load_field(_c_GrandParent_Parent_Child,
+             &_f_GrandParent_Parent_Child__childValue, "childValue",
+             "Ljava/lang/Object;");
+  (*jniEnv)->SetObjectField(jniEnv, self_,
+                            _f_GrandParent_Parent_Child__childValue, value);
   return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 

--- a/jnigen/test/simple_package_test/c_based/c_bindings/simple_package.c
+++ b/jnigen/test/simple_package_test/c_based/c_bindings/simple_package.c
@@ -1513,7 +1513,7 @@ jclass _c_GrandParent_Parent = NULL;
 
 jmethodID _m_GrandParent_Parent__ctor = NULL;
 FFI_PLUGIN_EXPORT
-JniResult GrandParent_Parent__ctor(jobject newValue) {
+JniResult GrandParent_Parent__ctor(jobject _parent, jobject newValue) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent,
@@ -1521,44 +1521,14 @@ JniResult GrandParent_Parent__ctor(jobject newValue) {
   if (_c_GrandParent_Parent == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
   load_method(_c_GrandParent_Parent, &_m_GrandParent_Parent__ctor, "<init>",
-              "(Ljava/lang/Object;)V");
+              "(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/"
+              "Object;)V");
   if (_m_GrandParent_Parent__ctor == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  jobject _result = (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent,
-                                         _m_GrandParent_Parent__ctor, newValue);
+  jobject _result =
+      (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent,
+                           _m_GrandParent_Parent__ctor, _parent, newValue);
   return to_global_ref_result(_result);
-}
-
-jfieldID _f_GrandParent_Parent__grandParentValue = NULL;
-FFI_PLUGIN_EXPORT
-JniResult get_GrandParent_Parent__grandParentValue(jobject self_) {
-  load_env();
-  load_class_global_ref(
-      &_c_GrandParent_Parent,
-      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
-  if (_c_GrandParent_Parent == NULL)
-    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__grandParentValue,
-             "grandParentValue", "Ljava/lang/Object;");
-  jobject _result = (*jniEnv)->GetObjectField(
-      jniEnv, self_, _f_GrandParent_Parent__grandParentValue);
-  return to_global_ref_result(_result);
-}
-
-FFI_PLUGIN_EXPORT
-JniResult set_GrandParent_Parent__grandParentValue(jobject self_,
-                                                   jobject value) {
-  load_env();
-  load_class_global_ref(
-      &_c_GrandParent_Parent,
-      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
-  if (_c_GrandParent_Parent == NULL)
-    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__grandParentValue,
-             "grandParentValue", "Ljava/lang/Object;");
-  (*jniEnv)->SetObjectField(jniEnv, self_,
-                            _f_GrandParent_Parent__grandParentValue, value);
-  return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 
 jfieldID _f_GrandParent_Parent__parentValue = NULL;
@@ -1592,12 +1562,42 @@ JniResult set_GrandParent_Parent__parentValue(jobject self_, jobject value) {
   return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 
+jfieldID _f_GrandParent_Parent__value = NULL;
+FFI_PLUGIN_EXPORT
+JniResult get_GrandParent_Parent__value(jobject self_) {
+  load_env();
+  load_class_global_ref(
+      &_c_GrandParent_Parent,
+      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
+  if (_c_GrandParent_Parent == NULL)
+    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
+  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__value, "value",
+             "Ljava/lang/Object;");
+  jobject _result =
+      (*jniEnv)->GetObjectField(jniEnv, self_, _f_GrandParent_Parent__value);
+  return to_global_ref_result(_result);
+}
+
+FFI_PLUGIN_EXPORT
+JniResult set_GrandParent_Parent__value(jobject self_, jobject value) {
+  load_env();
+  load_class_global_ref(
+      &_c_GrandParent_Parent,
+      "com/github/dart_lang/jnigen/generics/GrandParent$Parent");
+  if (_c_GrandParent_Parent == NULL)
+    return (JniResult){.value = {.j = 0}, .exception = check_exception()};
+  load_field(_c_GrandParent_Parent, &_f_GrandParent_Parent__value, "value",
+             "Ljava/lang/Object;");
+  (*jniEnv)->SetObjectField(jniEnv, self_, _f_GrandParent_Parent__value, value);
+  return (JniResult){.value = {.j = 0}, .exception = check_exception()};
+}
+
 // com.github.dart_lang.jnigen.generics.GrandParent$Parent$Child
 jclass _c_GrandParent_Parent_Child = NULL;
 
 jmethodID _m_GrandParent_Parent_Child__ctor = NULL;
 FFI_PLUGIN_EXPORT
-JniResult GrandParent_Parent_Child__ctor(jobject newValue) {
+JniResult GrandParent_Parent_Child__ctor(jobject _parent, jobject newValue) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent_Child,
@@ -1605,12 +1605,14 @@ JniResult GrandParent_Parent_Child__ctor(jobject newValue) {
   if (_c_GrandParent_Parent_Child == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
   load_method(_c_GrandParent_Parent_Child, &_m_GrandParent_Parent_Child__ctor,
-              "<init>", "(Ljava/lang/Object;)V");
+              "<init>",
+              "(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/"
+              "lang/Object;)V");
   if (_m_GrandParent_Parent_Child__ctor == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  jobject _result =
-      (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent_Child,
-                           _m_GrandParent_Parent_Child__ctor, newValue);
+  jobject _result = (*jniEnv)->NewObject(jniEnv, _c_GrandParent_Parent_Child,
+                                         _m_GrandParent_Parent_Child__ctor,
+                                         _parent, newValue);
   return to_global_ref_result(_result);
 }
 
@@ -1682,37 +1684,34 @@ JniResult set_GrandParent_Parent_Child__parentValue(jobject self_,
   return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 
-jfieldID _f_GrandParent_Parent_Child__childValue = NULL;
+jfieldID _f_GrandParent_Parent_Child__value = NULL;
 FFI_PLUGIN_EXPORT
-JniResult get_GrandParent_Parent_Child__childValue(jobject self_) {
+JniResult get_GrandParent_Parent_Child__value(jobject self_) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent_Child,
       "com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child");
   if (_c_GrandParent_Parent_Child == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent_Child,
-             &_f_GrandParent_Parent_Child__childValue, "childValue",
-             "Ljava/lang/Object;");
+  load_field(_c_GrandParent_Parent_Child, &_f_GrandParent_Parent_Child__value,
+             "value", "Ljava/lang/Object;");
   jobject _result = (*jniEnv)->GetObjectField(
-      jniEnv, self_, _f_GrandParent_Parent_Child__childValue);
+      jniEnv, self_, _f_GrandParent_Parent_Child__value);
   return to_global_ref_result(_result);
 }
 
 FFI_PLUGIN_EXPORT
-JniResult set_GrandParent_Parent_Child__childValue(jobject self_,
-                                                   jobject value) {
+JniResult set_GrandParent_Parent_Child__value(jobject self_, jobject value) {
   load_env();
   load_class_global_ref(
       &_c_GrandParent_Parent_Child,
       "com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child");
   if (_c_GrandParent_Parent_Child == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_field(_c_GrandParent_Parent_Child,
-             &_f_GrandParent_Parent_Child__childValue, "childValue",
-             "Ljava/lang/Object;");
-  (*jniEnv)->SetObjectField(jniEnv, self_,
-                            _f_GrandParent_Parent_Child__childValue, value);
+  load_field(_c_GrandParent_Parent_Child, &_f_GrandParent_Parent_Child__value,
+             "value", "Ljava/lang/Object;");
+  (*jniEnv)->SetObjectField(jniEnv, self_, _f_GrandParent_Parent_Child__value,
+                            value);
   return (JniResult){.value = {.j = 0}, .exception = check_exception()};
 }
 
@@ -1774,7 +1773,8 @@ jclass _c_GrandParent_StaticParent_Child = NULL;
 
 jmethodID _m_GrandParent_StaticParent_Child__ctor = NULL;
 FFI_PLUGIN_EXPORT
-JniResult GrandParent_StaticParent_Child__ctor(jobject parentValue,
+JniResult GrandParent_StaticParent_Child__ctor(jobject _parent,
+                                               jobject parentValue,
                                                jobject value) {
   load_env();
   load_class_global_ref(
@@ -1782,14 +1782,16 @@ JniResult GrandParent_StaticParent_Child__ctor(jobject parentValue,
       "com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child");
   if (_c_GrandParent_StaticParent_Child == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  load_method(_c_GrandParent_StaticParent_Child,
-              &_m_GrandParent_StaticParent_Child__ctor, "<init>",
-              "(Ljava/lang/Object;Ljava/lang/Object;)V");
+  load_method(
+      _c_GrandParent_StaticParent_Child,
+      &_m_GrandParent_StaticParent_Child__ctor, "<init>",
+      "(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/"
+      "lang/Object;Ljava/lang/Object;)V");
   if (_m_GrandParent_StaticParent_Child__ctor == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
   jobject _result = (*jniEnv)->NewObject(
       jniEnv, _c_GrandParent_StaticParent_Child,
-      _m_GrandParent_StaticParent_Child__ctor, parentValue, value);
+      _m_GrandParent_StaticParent_Child__ctor, _parent, parentValue, value);
   return to_global_ref_result(_result);
 }
 
@@ -1935,18 +1937,19 @@ jclass _c_MyMap_MyEntry = NULL;
 
 jmethodID _m_MyMap_MyEntry__ctor = NULL;
 FFI_PLUGIN_EXPORT
-JniResult MyMap_MyEntry__ctor(jobject key, jobject value) {
+JniResult MyMap_MyEntry__ctor(jobject _parent, jobject key, jobject value) {
   load_env();
   load_class_global_ref(&_c_MyMap_MyEntry,
                         "com/github/dart_lang/jnigen/generics/MyMap$MyEntry");
   if (_c_MyMap_MyEntry == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
   load_method(_c_MyMap_MyEntry, &_m_MyMap_MyEntry__ctor, "<init>",
-              "(Ljava/lang/Object;Ljava/lang/Object;)V");
+              "(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/"
+              "Object;Ljava/lang/Object;)V");
   if (_m_MyMap_MyEntry__ctor == NULL)
     return (JniResult){.value = {.j = 0}, .exception = check_exception()};
-  jobject _result = (*jniEnv)->NewObject(jniEnv, _c_MyMap_MyEntry,
-                                         _m_MyMap_MyEntry__ctor, key, value);
+  jobject _result = (*jniEnv)->NewObject(
+      jniEnv, _c_MyMap_MyEntry, _m_MyMap_MyEntry__ctor, _parent, key, value);
   return to_global_ref_result(_result);
 }
 

--- a/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
@@ -1518,6 +1518,33 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     );
   }
 
+  static final _get_grandParentValue = jniLookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                jni.JObjectPtr,
+              )>>("get_GrandParent_Parent__grandParentValue")
+      .asFunction<
+          jni.JniResult Function(
+            jni.JObjectPtr,
+          )>();
+
+  static final _set_grandParentValue = jniLookup<
+              ffi.NativeFunction<
+                  jni.JniResult Function(
+                      jni.JObjectPtr, ffi.Pointer<ffi.Void>)>>(
+          "set_GrandParent_Parent__grandParentValue")
+      .asFunction<
+          jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
+
+  /// from: public T grandParentValue
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  $T get grandParentValue => T.fromRef(_get_grandParentValue(reference).object);
+
+  /// from: public T grandParentValue
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  set grandParentValue($T value) =>
+      _set_grandParentValue(reference, value.reference).check();
+
   static final _get_parentValue = jniLookup<
           ffi.NativeFunction<
               jni.JniResult Function(
@@ -1536,64 +1563,32 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
       .asFunction<
           jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
 
-  /// from: public T parentValue
+  /// from: public S parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $T get parentValue => T.fromRef(_get_parentValue(reference).object);
+  $S get parentValue => S.fromRef(_get_parentValue(reference).object);
 
-  /// from: public T parentValue
+  /// from: public S parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set parentValue($T value) =>
+  set parentValue($S value) =>
       _set_parentValue(reference, value.reference).check();
-
-  static final _get_value = jniLookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                jni.JObjectPtr,
-              )>>("get_GrandParent_Parent__value")
-      .asFunction<
-          jni.JniResult Function(
-            jni.JObjectPtr,
-          )>();
-
-  static final _set_value = jniLookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(jni.JObjectPtr,
-                  ffi.Pointer<ffi.Void>)>>("set_GrandParent_Parent__value")
-      .asFunction<
-          jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
-
-  /// from: public S value
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  $S get value => S.fromRef(_get_value(reference).object);
-
-  /// from: public S value
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  set value($S value) => _set_value(reference, value.reference).check();
 
   static final _ctor = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>,
+              jni.JniResult Function(
                   ffi.Pointer<ffi.Void>)>>("GrandParent_Parent__ctor")
-      .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
 
-  /// from: public void <init>(T parentValue, S value)
+  /// from: public void <init>(S newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent(
-    $T parentValue,
-    $S value, {
-    jni.JObjType<$T>? T,
+    $S newValue, {
+    required jni.JObjType<$T> T,
     jni.JObjType<$S>? S,
   }) {
-    T ??= jni.lowestCommonSuperType([
-      parentValue.$type,
-    ]) as jni.JObjType<$T>;
     S ??= jni.lowestCommonSuperType([
-      value.$type,
+      newValue.$type,
     ]) as jni.JObjType<$S>;
-    return GrandParent_Parent.fromRef(
-        T, S, _ctor(parentValue.reference, value.reference).object);
+    return GrandParent_Parent.fromRef(T, S, _ctor(newValue.reference).object);
   }
 }
 
@@ -1719,68 +1714,52 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
   set parentValue($S value) =>
       _set_parentValue(reference, value.reference).check();
 
-  static final _get_value = jniLookup<
+  static final _get_childValue = jniLookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 jni.JObjectPtr,
-              )>>("get_GrandParent_Parent_Child__value")
+              )>>("get_GrandParent_Parent_Child__childValue")
       .asFunction<
           jni.JniResult Function(
             jni.JObjectPtr,
           )>();
 
-  static final _set_value = jniLookup<
+  static final _set_childValue = jniLookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       jni.JObjectPtr, ffi.Pointer<ffi.Void>)>>(
-          "set_GrandParent_Parent_Child__value")
+          "set_GrandParent_Parent_Child__childValue")
       .asFunction<
           jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
 
-  /// from: public U value
+  /// from: public U childValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $U get value => U.fromRef(_get_value(reference).object);
+  $U get childValue => U.fromRef(_get_childValue(reference).object);
 
-  /// from: public U value
+  /// from: public U childValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set value($U value) => _set_value(reference, value.reference).check();
+  set childValue($U value) =>
+      _set_childValue(reference, value.reference).check();
 
   static final _ctor = jniLookup<
           ffi.NativeFunction<
               jni.JniResult Function(
-                  ffi.Pointer<ffi.Void>,
-                  ffi.Pointer<ffi.Void>,
                   ffi.Pointer<ffi.Void>)>>("GrandParent_Parent_Child__ctor")
-      .asFunction<
-          jni.JniResult Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>,
-              ffi.Pointer<ffi.Void>)>();
+      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
 
-  /// from: public void <init>(T grandParentValue, S parentValue, U value)
+  /// from: public void <init>(U newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent_Child(
-    $T grandParentValue,
-    $S parentValue,
-    $U value, {
-    jni.JObjType<$T>? T,
-    jni.JObjType<$S>? S,
+    $U newValue, {
+    required jni.JObjType<$T> T,
+    required jni.JObjType<$S> S,
     jni.JObjType<$U>? U,
   }) {
-    T ??= jni.lowestCommonSuperType([
-      grandParentValue.$type,
-    ]) as jni.JObjType<$T>;
-    S ??= jni.lowestCommonSuperType([
-      parentValue.$type,
-    ]) as jni.JObjType<$S>;
     U ??= jni.lowestCommonSuperType([
-      value.$type,
+      newValue.$type,
     ]) as jni.JObjType<$U>;
     return GrandParent_Parent_Child.fromRef(
-        T,
-        S,
-        U,
-        _ctor(grandParentValue.reference, parentValue.reference,
-                value.reference)
-            .object);
+        T, S, U, _ctor(newValue.reference).object);
   }
 }
 

--- a/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
@@ -1518,33 +1518,6 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     );
   }
 
-  static final _get_grandParentValue = jniLookup<
-          ffi.NativeFunction<
-              jni.JniResult Function(
-                jni.JObjectPtr,
-              )>>("get_GrandParent_Parent__grandParentValue")
-      .asFunction<
-          jni.JniResult Function(
-            jni.JObjectPtr,
-          )>();
-
-  static final _set_grandParentValue = jniLookup<
-              ffi.NativeFunction<
-                  jni.JniResult Function(
-                      jni.JObjectPtr, ffi.Pointer<ffi.Void>)>>(
-          "set_GrandParent_Parent__grandParentValue")
-      .asFunction<
-          jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
-
-  /// from: public T grandParentValue
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  $T get grandParentValue => T.fromRef(_get_grandParentValue(reference).object);
-
-  /// from: public T grandParentValue
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  set grandParentValue($T value) =>
-      _set_grandParentValue(reference, value.reference).check();
-
   static final _get_parentValue = jniLookup<
           ffi.NativeFunction<
               jni.JniResult Function(
@@ -1563,32 +1536,64 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
       .asFunction<
           jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
 
-  /// from: public S parentValue
+  /// from: public T parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $S get parentValue => S.fromRef(_get_parentValue(reference).object);
+  $T get parentValue => T.fromRef(_get_parentValue(reference).object);
 
-  /// from: public S parentValue
+  /// from: public T parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set parentValue($S value) =>
+  set parentValue($T value) =>
       _set_parentValue(reference, value.reference).check();
+
+  static final _get_value = jniLookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(
+                jni.JObjectPtr,
+              )>>("get_GrandParent_Parent__value")
+      .asFunction<
+          jni.JniResult Function(
+            jni.JObjectPtr,
+          )>();
+
+  static final _set_value = jniLookup<
+          ffi.NativeFunction<
+              jni.JniResult Function(jni.JObjectPtr,
+                  ffi.Pointer<ffi.Void>)>>("set_GrandParent_Parent__value")
+      .asFunction<
+          jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
+
+  /// from: public S value
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  $S get value => S.fromRef(_get_value(reference).object);
+
+  /// from: public S value
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  set value($S value) => _set_value(reference, value.reference).check();
 
   static final _ctor = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(
+              jni.JniResult Function(ffi.Pointer<ffi.Void>,
                   ffi.Pointer<ffi.Void>)>>("GrandParent_Parent__ctor")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
-  /// from: public void <init>(S newValue)
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $parent, S newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent(
+    GrandParent<$T> $parent,
     $S newValue, {
-    required jni.JObjType<$T> T,
+    jni.JObjType<$T>? T,
     jni.JObjType<$S>? S,
   }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParentType).T,
+    ]) as jni.JObjType<$T>;
     S ??= jni.lowestCommonSuperType([
       newValue.$type,
     ]) as jni.JObjType<$S>;
-    return GrandParent_Parent.fromRef(T, S, _ctor(newValue.reference).object);
+    return GrandParent_Parent.fromRef(
+        T, S, _ctor($parent.reference, newValue.reference).object);
   }
 }
 
@@ -1714,52 +1719,60 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
   set parentValue($S value) =>
       _set_parentValue(reference, value.reference).check();
 
-  static final _get_childValue = jniLookup<
+  static final _get_value = jniLookup<
           ffi.NativeFunction<
               jni.JniResult Function(
                 jni.JObjectPtr,
-              )>>("get_GrandParent_Parent_Child__childValue")
+              )>>("get_GrandParent_Parent_Child__value")
       .asFunction<
           jni.JniResult Function(
             jni.JObjectPtr,
           )>();
 
-  static final _set_childValue = jniLookup<
+  static final _set_value = jniLookup<
               ffi.NativeFunction<
                   jni.JniResult Function(
                       jni.JObjectPtr, ffi.Pointer<ffi.Void>)>>(
-          "set_GrandParent_Parent_Child__childValue")
+          "set_GrandParent_Parent_Child__value")
       .asFunction<
           jni.JniResult Function(jni.JObjectPtr, ffi.Pointer<ffi.Void>)>();
 
-  /// from: public U childValue
+  /// from: public U value
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $U get childValue => U.fromRef(_get_childValue(reference).object);
+  $U get value => U.fromRef(_get_value(reference).object);
 
-  /// from: public U childValue
+  /// from: public U value
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set childValue($U value) =>
-      _set_childValue(reference, value.reference).check();
+  set value($U value) => _set_value(reference, value.reference).check();
 
   static final _ctor = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(
+              jni.JniResult Function(ffi.Pointer<ffi.Void>,
                   ffi.Pointer<ffi.Void>)>>("GrandParent_Parent_Child__ctor")
-      .asFunction<jni.JniResult Function(ffi.Pointer<ffi.Void>)>();
+      .asFunction<
+          jni.JniResult Function(
+              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
 
-  /// from: public void <init>(U newValue)
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $parent, U newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent_Child(
+    GrandParent_Parent<$T, $S> $parent,
     $U newValue, {
-    required jni.JObjType<$T> T,
-    required jni.JObjType<$S> S,
+    jni.JObjType<$T>? T,
+    jni.JObjType<$S>? S,
     jni.JObjType<$U>? U,
   }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).T,
+    ]) as jni.JObjType<$T>;
+    S ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).S,
+    ]) as jni.JObjType<$S>;
     U ??= jni.lowestCommonSuperType([
       newValue.$type,
     ]) as jni.JObjType<$U>;
     return GrandParent_Parent_Child.fromRef(
-        T, S, U, _ctor(newValue.reference).object);
+        T, S, U, _ctor($parent.reference, newValue.reference).object);
   }
 }
 
@@ -1985,16 +1998,17 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
 
   static final _ctor = jniLookup<
               ffi.NativeFunction<
-                  jni.JniResult Function(
+                  jni.JniResult Function(ffi.Pointer<ffi.Void>,
                       ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>>(
           "GrandParent_StaticParent_Child__ctor")
       .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>)>();
 
-  /// from: public void <init>(S parentValue, U value)
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $parent, S parentValue, U value)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_StaticParent_Child(
+    GrandParent_StaticParent<$S> $parent,
     $S parentValue,
     $U value, {
     jni.JObjType<$S>? S,
@@ -2002,12 +2016,16 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
   }) {
     S ??= jni.lowestCommonSuperType([
       parentValue.$type,
+      ($parent.$type as $GrandParent_StaticParentType).S,
     ]) as jni.JObjType<$S>;
     U ??= jni.lowestCommonSuperType([
       value.$type,
     ]) as jni.JObjType<$U>;
     return GrandParent_StaticParent_Child.fromRef(
-        S, U, _ctor(parentValue.reference, value.reference).object);
+        S,
+        U,
+        _ctor($parent.reference, parentValue.reference, value.reference)
+            .object);
   }
 }
 
@@ -2249,15 +2267,18 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
 
   static final _ctor = jniLookup<
           ffi.NativeFunction<
-              jni.JniResult Function(ffi.Pointer<ffi.Void>,
+              jni.JniResult Function(
+                  ffi.Pointer<ffi.Void>,
+                  ffi.Pointer<ffi.Void>,
                   ffi.Pointer<ffi.Void>)>>("MyMap_MyEntry__ctor")
       .asFunction<
-          jni.JniResult Function(
-              ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>)>();
+          jni.JniResult Function(ffi.Pointer<ffi.Void>, ffi.Pointer<ffi.Void>,
+              ffi.Pointer<ffi.Void>)>();
 
-  /// from: public void <init>(K key, V value)
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.MyMap $parent, K key, V value)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory MyMap_MyEntry(
+    MyMap<$K, $V> $parent,
     $K key,
     $V value, {
     jni.JObjType<$K>? K,
@@ -2265,12 +2286,14 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
   }) {
     K ??= jni.lowestCommonSuperType([
       key.$type,
+      ($parent.$type as $MyMapType).K,
     ]) as jni.JObjType<$K>;
     V ??= jni.lowestCommonSuperType([
       value.$type,
+      ($parent.$type as $MyMapType).V,
     ]) as jni.JObjType<$V>;
     return MyMap_MyEntry.fromRef(
-        K, V, _ctor(key.reference, value.reference).object);
+        K, V, _ctor($parent.reference, key.reference, value.reference).object);
   }
 }
 

--- a/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
@@ -1424,62 +1424,58 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     );
   }
 
+  static final _id_grandParentValue = jni.Jni.accessors.getFieldIDOf(
+    _class.reference,
+    r"grandParentValue",
+    r"Ljava/lang/Object;",
+  );
+
+  /// from: public T grandParentValue
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  $T get grandParentValue => T.fromRef(jni.Jni.accessors
+      .getField(reference, _id_grandParentValue, jni.JniCallType.objectType)
+      .object);
+
+  /// from: public T grandParentValue
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  set grandParentValue($T value) => jni.Jni.env
+      .SetObjectField(reference, _id_grandParentValue, value.reference);
+
   static final _id_parentValue = jni.Jni.accessors.getFieldIDOf(
     _class.reference,
     r"parentValue",
     r"Ljava/lang/Object;",
   );
 
-  /// from: public T parentValue
+  /// from: public S parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $T get parentValue => T.fromRef(jni.Jni.accessors
+  $S get parentValue => S.fromRef(jni.Jni.accessors
       .getField(reference, _id_parentValue, jni.JniCallType.objectType)
       .object);
 
-  /// from: public T parentValue
+  /// from: public S parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set parentValue($T value) =>
+  set parentValue($S value) =>
       jni.Jni.env.SetObjectField(reference, _id_parentValue, value.reference);
 
-  static final _id_value = jni.Jni.accessors.getFieldIDOf(
-    _class.reference,
-    r"value",
-    r"Ljava/lang/Object;",
-  );
+  static final _id_ctor = jni.Jni.accessors
+      .getMethodIDOf(_class.reference, r"<init>", r"(Ljava/lang/Object;)V");
 
-  /// from: public S value
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  $S get value => S.fromRef(jni.Jni.accessors
-      .getField(reference, _id_value, jni.JniCallType.objectType)
-      .object);
-
-  /// from: public S value
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  set value($S value) =>
-      jni.Jni.env.SetObjectField(reference, _id_value, value.reference);
-
-  static final _id_ctor = jni.Jni.accessors.getMethodIDOf(
-      _class.reference, r"<init>", r"(Ljava/lang/Object;Ljava/lang/Object;)V");
-
-  /// from: public void <init>(T parentValue, S value)
+  /// from: public void <init>(S newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent(
-    $T parentValue,
-    $S value, {
-    jni.JObjType<$T>? T,
+    $S newValue, {
+    required jni.JObjType<$T> T,
     jni.JObjType<$S>? S,
   }) {
-    T ??= jni.lowestCommonSuperType([
-      parentValue.$type,
-    ]) as jni.JObjType<$T>;
     S ??= jni.lowestCommonSuperType([
-      value.$type,
+      newValue.$type,
     ]) as jni.JObjType<$S>;
     return GrandParent_Parent.fromRef(
         T,
         S,
-        jni.Jni.accessors.newObjectWithArgs(_class.reference, _id_ctor,
-            [parentValue.reference, value.reference]).object);
+        jni.Jni.accessors.newObjectWithArgs(
+            _class.reference, _id_ctor, [newValue.reference]).object);
   }
 }
 
@@ -1588,54 +1584,43 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
   set parentValue($S value) =>
       jni.Jni.env.SetObjectField(reference, _id_parentValue, value.reference);
 
-  static final _id_value = jni.Jni.accessors.getFieldIDOf(
+  static final _id_childValue = jni.Jni.accessors.getFieldIDOf(
     _class.reference,
-    r"value",
+    r"childValue",
     r"Ljava/lang/Object;",
   );
 
-  /// from: public U value
+  /// from: public U childValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $U get value => U.fromRef(jni.Jni.accessors
-      .getField(reference, _id_value, jni.JniCallType.objectType)
+  $U get childValue => U.fromRef(jni.Jni.accessors
+      .getField(reference, _id_childValue, jni.JniCallType.objectType)
       .object);
 
-  /// from: public U value
+  /// from: public U childValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set value($U value) =>
-      jni.Jni.env.SetObjectField(reference, _id_value, value.reference);
+  set childValue($U value) =>
+      jni.Jni.env.SetObjectField(reference, _id_childValue, value.reference);
 
-  static final _id_ctor = jni.Jni.accessors.getMethodIDOf(_class.reference,
-      r"<init>", r"(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)V");
+  static final _id_ctor = jni.Jni.accessors
+      .getMethodIDOf(_class.reference, r"<init>", r"(Ljava/lang/Object;)V");
 
-  /// from: public void <init>(T grandParentValue, S parentValue, U value)
+  /// from: public void <init>(U newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent_Child(
-    $T grandParentValue,
-    $S parentValue,
-    $U value, {
-    jni.JObjType<$T>? T,
-    jni.JObjType<$S>? S,
+    $U newValue, {
+    required jni.JObjType<$T> T,
+    required jni.JObjType<$S> S,
     jni.JObjType<$U>? U,
   }) {
-    T ??= jni.lowestCommonSuperType([
-      grandParentValue.$type,
-    ]) as jni.JObjType<$T>;
-    S ??= jni.lowestCommonSuperType([
-      parentValue.$type,
-    ]) as jni.JObjType<$S>;
     U ??= jni.lowestCommonSuperType([
-      value.$type,
+      newValue.$type,
     ]) as jni.JObjType<$U>;
     return GrandParent_Parent_Child.fromRef(
         T,
         S,
         U,
-        jni.Jni.accessors.newObjectWithArgs(_class.reference, _id_ctor, [
-          grandParentValue.reference,
-          parentValue.reference,
-          value.reference
-        ]).object);
+        jni.Jni.accessors.newObjectWithArgs(
+            _class.reference, _id_ctor, [newValue.reference]).object);
   }
 }
 

--- a/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
@@ -1424,58 +1424,64 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
     );
   }
 
-  static final _id_grandParentValue = jni.Jni.accessors.getFieldIDOf(
-    _class.reference,
-    r"grandParentValue",
-    r"Ljava/lang/Object;",
-  );
-
-  /// from: public T grandParentValue
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  $T get grandParentValue => T.fromRef(jni.Jni.accessors
-      .getField(reference, _id_grandParentValue, jni.JniCallType.objectType)
-      .object);
-
-  /// from: public T grandParentValue
-  /// The returned object must be deleted after use, by calling the `delete` method.
-  set grandParentValue($T value) => jni.Jni.env
-      .SetObjectField(reference, _id_grandParentValue, value.reference);
-
   static final _id_parentValue = jni.Jni.accessors.getFieldIDOf(
     _class.reference,
     r"parentValue",
     r"Ljava/lang/Object;",
   );
 
-  /// from: public S parentValue
+  /// from: public T parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $S get parentValue => S.fromRef(jni.Jni.accessors
+  $T get parentValue => T.fromRef(jni.Jni.accessors
       .getField(reference, _id_parentValue, jni.JniCallType.objectType)
       .object);
 
-  /// from: public S parentValue
+  /// from: public T parentValue
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set parentValue($S value) =>
+  set parentValue($T value) =>
       jni.Jni.env.SetObjectField(reference, _id_parentValue, value.reference);
 
-  static final _id_ctor = jni.Jni.accessors
-      .getMethodIDOf(_class.reference, r"<init>", r"(Ljava/lang/Object;)V");
+  static final _id_value = jni.Jni.accessors.getFieldIDOf(
+    _class.reference,
+    r"value",
+    r"Ljava/lang/Object;",
+  );
 
-  /// from: public void <init>(S newValue)
+  /// from: public S value
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  $S get value => S.fromRef(jni.Jni.accessors
+      .getField(reference, _id_value, jni.JniCallType.objectType)
+      .object);
+
+  /// from: public S value
+  /// The returned object must be deleted after use, by calling the `delete` method.
+  set value($S value) =>
+      jni.Jni.env.SetObjectField(reference, _id_value, value.reference);
+
+  static final _id_ctor = jni.Jni.accessors.getMethodIDOf(
+      _class.reference,
+      r"<init>",
+      r"(Lcom/github/dart_lang/jnigen/generics/GrandParent;Ljava/lang/Object;)V");
+
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent $parent, S newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent(
+    GrandParent<$T> $parent,
     $S newValue, {
-    required jni.JObjType<$T> T,
+    jni.JObjType<$T>? T,
     jni.JObjType<$S>? S,
   }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParentType).T,
+    ]) as jni.JObjType<$T>;
     S ??= jni.lowestCommonSuperType([
       newValue.$type,
     ]) as jni.JObjType<$S>;
     return GrandParent_Parent.fromRef(
         T,
         S,
-        jni.Jni.accessors.newObjectWithArgs(
-            _class.reference, _id_ctor, [newValue.reference]).object);
+        jni.Jni.accessors.newObjectWithArgs(_class.reference, _id_ctor,
+            [$parent.reference, newValue.reference]).object);
   }
 }
 
@@ -1584,34 +1590,43 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
   set parentValue($S value) =>
       jni.Jni.env.SetObjectField(reference, _id_parentValue, value.reference);
 
-  static final _id_childValue = jni.Jni.accessors.getFieldIDOf(
+  static final _id_value = jni.Jni.accessors.getFieldIDOf(
     _class.reference,
-    r"childValue",
+    r"value",
     r"Ljava/lang/Object;",
   );
 
-  /// from: public U childValue
+  /// from: public U value
   /// The returned object must be deleted after use, by calling the `delete` method.
-  $U get childValue => U.fromRef(jni.Jni.accessors
-      .getField(reference, _id_childValue, jni.JniCallType.objectType)
+  $U get value => U.fromRef(jni.Jni.accessors
+      .getField(reference, _id_value, jni.JniCallType.objectType)
       .object);
 
-  /// from: public U childValue
+  /// from: public U value
   /// The returned object must be deleted after use, by calling the `delete` method.
-  set childValue($U value) =>
-      jni.Jni.env.SetObjectField(reference, _id_childValue, value.reference);
+  set value($U value) =>
+      jni.Jni.env.SetObjectField(reference, _id_value, value.reference);
 
-  static final _id_ctor = jni.Jni.accessors
-      .getMethodIDOf(_class.reference, r"<init>", r"(Ljava/lang/Object;)V");
+  static final _id_ctor = jni.Jni.accessors.getMethodIDOf(
+      _class.reference,
+      r"<init>",
+      r"(Lcom/github/dart_lang/jnigen/generics/GrandParent$Parent;Ljava/lang/Object;)V");
 
-  /// from: public void <init>(U newValue)
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$Parent $parent, U newValue)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_Parent_Child(
+    GrandParent_Parent<$T, $S> $parent,
     $U newValue, {
-    required jni.JObjType<$T> T,
-    required jni.JObjType<$S> S,
+    jni.JObjType<$T>? T,
+    jni.JObjType<$S>? S,
     jni.JObjType<$U>? U,
   }) {
+    T ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).T,
+    ]) as jni.JObjType<$T>;
+    S ??= jni.lowestCommonSuperType([
+      ($parent.$type as $GrandParent_ParentType).S,
+    ]) as jni.JObjType<$S>;
     U ??= jni.lowestCommonSuperType([
       newValue.$type,
     ]) as jni.JObjType<$U>;
@@ -1619,8 +1634,8 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
         T,
         S,
         U,
-        jni.Jni.accessors.newObjectWithArgs(
-            _class.reference, _id_ctor, [newValue.reference]).object);
+        jni.Jni.accessors.newObjectWithArgs(_class.reference, _id_ctor,
+            [$parent.reference, newValue.reference]).object);
   }
 }
 
@@ -1823,11 +1838,14 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
       jni.Jni.env.SetObjectField(reference, _id_value, value.reference);
 
   static final _id_ctor = jni.Jni.accessors.getMethodIDOf(
-      _class.reference, r"<init>", r"(Ljava/lang/Object;Ljava/lang/Object;)V");
+      _class.reference,
+      r"<init>",
+      r"(Lcom/github/dart_lang/jnigen/generics/GrandParent$StaticParent;Ljava/lang/Object;Ljava/lang/Object;)V");
 
-  /// from: public void <init>(S parentValue, U value)
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.GrandParent$StaticParent $parent, S parentValue, U value)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory GrandParent_StaticParent_Child(
+    GrandParent_StaticParent<$S> $parent,
     $S parentValue,
     $U value, {
     jni.JObjType<$S>? S,
@@ -1835,6 +1853,7 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
   }) {
     S ??= jni.lowestCommonSuperType([
       parentValue.$type,
+      ($parent.$type as $GrandParent_StaticParentType).S,
     ]) as jni.JObjType<$S>;
     U ??= jni.lowestCommonSuperType([
       value.$type,
@@ -1842,8 +1861,11 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
     return GrandParent_StaticParent_Child.fromRef(
         S,
         U,
-        jni.Jni.accessors.newObjectWithArgs(_class.reference, _id_ctor,
-            [parentValue.reference, value.reference]).object);
+        jni.Jni.accessors.newObjectWithArgs(_class.reference, _id_ctor, [
+          $parent.reference,
+          parentValue.reference,
+          value.reference
+        ]).object);
   }
 }
 
@@ -2069,11 +2091,14 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
       jni.Jni.env.SetObjectField(reference, _id_value, value.reference);
 
   static final _id_ctor = jni.Jni.accessors.getMethodIDOf(
-      _class.reference, r"<init>", r"(Ljava/lang/Object;Ljava/lang/Object;)V");
+      _class.reference,
+      r"<init>",
+      r"(Lcom/github/dart_lang/jnigen/generics/MyMap;Ljava/lang/Object;Ljava/lang/Object;)V");
 
-  /// from: public void <init>(K key, V value)
+  /// from: public void <init>(com.github.dart_lang.jnigen.generics.MyMap $parent, K key, V value)
   /// The returned object must be deleted after use, by calling the `delete` method.
   factory MyMap_MyEntry(
+    MyMap<$K, $V> $parent,
     $K key,
     $V value, {
     jni.JObjType<$K>? K,
@@ -2081,15 +2106,17 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
   }) {
     K ??= jni.lowestCommonSuperType([
       key.$type,
+      ($parent.$type as $MyMapType).K,
     ]) as jni.JObjType<$K>;
     V ??= jni.lowestCommonSuperType([
       value.$type,
+      ($parent.$type as $MyMapType).V,
     ]) as jni.JObjType<$V>;
     return MyMap_MyEntry.fromRef(
         K,
         V,
         jni.Jni.accessors.newObjectWithArgs(_class.reference, _id_ctor,
-            [key.reference, value.reference]).object);
+            [$parent.reference, key.reference, value.reference]).object);
   }
 }
 

--- a/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/generics/GrandParent.java
+++ b/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/generics/GrandParent.java
@@ -12,11 +12,11 @@ public class GrandParent<T> {
   }
 
   public Parent<String> stringParent() {
-    return new Parent<>(value, "Hello");
+    return new Parent<>("Hello");
   }
 
   public <S> Parent<S> varParent(S nestedValue) {
-    return new Parent<>(value, nestedValue);
+    return new Parent<>(nestedValue);
   }
 
   public static StaticParent<String> stringStaticParent() {
@@ -51,23 +51,23 @@ public class GrandParent<T> {
   }
 
   public class Parent<S> {
-    public T parentValue;
-    public S value;
+    public T grandParentValue;
+    public S parentValue;
 
-    public Parent(T parentValue, S value) {
-      this.parentValue = parentValue;
-      this.value = value;
+    public Parent(S newValue) {
+      grandParentValue = value;
+      this.parentValue = newValue;
     }
 
     public class Child<U> {
       public T grandParentValue;
       public S parentValue;
-      public U value;
+      public U childValue;
 
-      public Child(T grandParentValue, S parentValue, U value) {
+      public Child(U newValue) {
         this.grandParentValue = grandParentValue;
         this.parentValue = parentValue;
-        this.value = value;
+        this.childValue = newValue;
       }
     }
   }

--- a/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/generics/GrandParent.java
+++ b/jnigen/test/simple_package_test/java/com/github/dart_lang/jnigen/generics/GrandParent.java
@@ -51,23 +51,23 @@ public class GrandParent<T> {
   }
 
   public class Parent<S> {
-    public T grandParentValue;
-    public S parentValue;
+    public T parentValue;
+    public S value;
 
     public Parent(S newValue) {
-      grandParentValue = value;
-      this.parentValue = newValue;
+      parentValue = GrandParent.this.value;
+      value = newValue;
     }
 
     public class Child<U> {
       public T grandParentValue;
       public S parentValue;
-      public U childValue;
+      public U value;
 
       public Child(U newValue) {
-        this.grandParentValue = grandParentValue;
-        this.parentValue = parentValue;
-        this.childValue = newValue;
+        this.grandParentValue = GrandParent.this.value;
+        this.parentValue = Parent.this.value;
+        this.value = newValue;
       }
     }
   }

--- a/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -395,7 +395,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             "!",
           );
           expect(
-            strParent.value.toDartString(deleteOriginal: true),
+            strParent.parentValue.toDartString(deleteOriginal: true),
             "Hello",
           );
 
@@ -409,7 +409,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             "!",
           );
           expect(
-            (exampleParent.value..deletedIn(arena)).getNumber(),
+            (exampleParent.parentValue..deletedIn(arena)).getNumber(),
             0,
           );
           // TODO(#139): test constructing Child, currently does not work due

--- a/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -395,7 +395,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             "!",
           );
           expect(
-            strParent.parentValue.toDartString(deleteOriginal: true),
+            strParent.value.toDartString(deleteOriginal: true),
             "Hello",
           );
 
@@ -409,7 +409,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
             "!",
           );
           expect(
-            (exampleParent.parentValue..deletedIn(arena)).getNumber(),
+            (exampleParent.value..deletedIn(arena)).getNumber(),
             0,
           );
           // TODO(#139): test constructing Child, currently does not work due
@@ -417,6 +417,22 @@ void registerTests(String groupName, TestRunnerCallback test) {
         });
       });
     });
+    test('Constructing non-static nested classes', () {
+      using((arena) {
+        final grandParent = GrandParent(1.toJInteger())..deletedIn(arena);
+        final parent = GrandParent_Parent(grandParent, 2.toJInteger())
+          ..deletedIn(arena);
+        final child = GrandParent_Parent_Child(parent, 3.toJInteger())
+          ..deletedIn(arena);
+        expect(grandParent.value.intValue(deleteOriginal: true), 1);
+        expect(parent.parentValue.intValue(deleteOriginal: true), 1);
+        expect(parent.value.intValue(deleteOriginal: true), 2);
+        expect(child.grandParentValue.intValue(deleteOriginal: true), 1);
+        expect(child.parentValue.intValue(deleteOriginal: true), 2);
+        expect(child.value.intValue(deleteOriginal: true), 3);
+      });
+    });
+
     group('Generic type inference', () {
       test('MyStack.of1', () {
         using((arena) {

--- a/jnigen/test/test_util/test_util.dart
+++ b/jnigen/test/test_util/test_util.dart
@@ -91,10 +91,10 @@ void comparePaths(String path1, String path2) {
         "Paths $path1 and $path2 differ, comparing by ignoring all spaces");
     // From https://stackoverflow.com/questions/33159394/ignore-all-whitespace-changes-with-git-diff-between-commits/33159593#33159593
     final fallbackDiffProc = Process.runSync("git", [
-      ...diffCommand,
       '-c',
       'core.whitespace=-trailing-space,-indent-with-non-tab,-tab-in-indent',
       'diff',
+      '--no-index',
       '-U0',
       "--word-diff-regex='[^[:space:]]'",
       path1,

--- a/jnigen/test/test_util/test_util.dart
+++ b/jnigen/test/test_util/test_util.dart
@@ -89,8 +89,17 @@ void comparePaths(String path1, String path2) {
     final originalDiff = diffProc.stdout;
     log.warning(
         "Paths $path1 and $path2 differ, comparing by ignoring all spaces");
-    final fallbackDiffProc = Process.runSync(
-        "git", [...diffCommand, '--ignore-all-space', path1, path2]);
+    // From https://stackoverflow.com/questions/33159394/ignore-all-whitespace-changes-with-git-diff-between-commits/33159593#33159593
+    final fallbackDiffProc = Process.runSync("git", [
+      ...diffCommand,
+      '-c',
+      'core.whitespace=-trailing-space,-indent-with-non-tab,-tab-in-indent',
+      'diff',
+      '-U0',
+      "--word-diff-regex='[^[:space:]]'",
+      path1,
+      path2,
+    ]);
     if (fallbackDiffProc.exitCode != 0) {
       stderr.writeln(originalDiff);
       throw Exception("Paths $path1 and $path2 differ");

--- a/jnigen/test/test_util/test_util.dart
+++ b/jnigen/test/test_util/test_util.dart
@@ -88,18 +88,9 @@ void comparePaths(String path1, String path2) {
   if (diffProc.exitCode != 0) {
     final originalDiff = diffProc.stdout;
     log.warning(
-        "Paths $path1 and $path2 differ, comparing by ignoring all spaces");
-    // From https://stackoverflow.com/questions/33159394/ignore-all-whitespace-changes-with-git-diff-between-commits/33159593#33159593
-    final fallbackDiffProc = Process.runSync("git", [
-      '-c',
-      'core.whitespace=-trailing-space,-indent-with-non-tab,-tab-in-indent',
-      'diff',
-      '--no-index',
-      '-U0',
-      "--word-diff-regex='[^[:space:]]'",
-      path1,
-      path2,
-    ]);
+        "Paths $path1 and $path2 differ, comparing by ignoring space change");
+    final fallbackDiffProc = Process.runSync(
+        "git", [...diffCommand, '--ignore-space-change', path1, path2]);
     if (fallbackDiffProc.exitCode != 0) {
       stderr.writeln(originalDiff);
       throw Exception("Paths $path1 and $path2 differ");

--- a/jnigen/test/test_util/test_util.dart
+++ b/jnigen/test/test_util/test_util.dart
@@ -88,9 +88,9 @@ void comparePaths(String path1, String path2) {
   if (diffProc.exitCode != 0) {
     final originalDiff = diffProc.stdout;
     log.warning(
-        "Paths $path1 and $path2 differ, comparing by ignoring space change");
+        "Paths $path1 and $path2 differ, comparing by ignoring all spaces");
     final fallbackDiffProc = Process.runSync(
-        "git", [...diffCommand, '--ignore-space-change', path1, path2]);
+        "git", [...diffCommand, '--ignore-all-space', path1, path2]);
     if (fallbackDiffProc.exitCode != 0) {
       stderr.writeln(originalDiff);
       throw Exception("Paths $path1 and $path2 differ");


### PR DESCRIPTION
Take a non-static nested class like `B`:

```java
public class A {
  public class B {
    // ...
    public B(int a, int b) { /* ... */ }
  }
}
```

Right now, we're incorrectly generating `B`'s constructor like `B(int a, int b)`, but since `B` is not static, it depends on its outer class and has to take it as its first parameter. This PR fixes this issue so `B`'s constructor turns into `B(A $parent, int a, int b)` instead.

---

We could make the constructors for the nested class private, and generate a temporary class `$BBuilder` which takes an instance of `A` as it's constructor and use it as a `B` getter in `A`:

```dart
class A {
  // ...
  $BBuilder get B => $BBuilder(this);
}

class $BBuilder {
  final A $parent;
  $BBuilder(this.$parent);

  B call(int a, int b) {
    return B._($parent, a, b);
  }
}
```

Although making the syntax of creating the nested class nicer (`final b = a.B(2, 3);` instead of `final b = B(a, 2, 3);`), it makes the code generation more complicated and it's not the highest priority. So this feature is not included in this PR. 
