### PR TITLE
Clean up interface implementation using auxiliary generated classes

### DIFF
--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -15,11 +15,11 @@ import 'c_generator.dart';
 import 'resolver.dart';
 import 'visitor.dart';
 
-// Import prefixes
+// Import prefixes.
 const _jni = 'jni';
 const _ffi = 'ffi';
 
-// package:jni types
+// package:jni types.
 const _jType = '$_jni.JObjType';
 const _jPointer = '$_jni.JObjectPtr';
 const _jArray = '$_jni.JArray';
@@ -27,10 +27,10 @@ const _jObject = '$_jni.JObject';
 const _jResult = '$_jni.JniResult';
 const _jCallType = '$_jni.JniCallType';
 
-// package:ffi types
+// package:ffi types.
 const _voidPointer = '$_ffi.Pointer<$_ffi.Void>';
 
-// Prefixes and suffixes
+// Prefixes and suffixes.
 const _typeParamPrefix = '\$';
 
 // Misc.
@@ -41,12 +41,11 @@ const _accessors = '$_jni.Jni.accessors';
 const _lookup = 'jniLookup';
 const _selfPointer = 'reference';
 
-// Docs
+// Docs.
 const _deleteInstruction =
     '  /// The returned object must be deleted after use, '
     'by calling the `delete` method.';
 
-// Helper methods
 extension on Iterable<String> {
   /// Similar to [join] but adds the [separator] to the end as well.
   String delimited([String separator = '']) {
@@ -283,7 +282,7 @@ import "package:jni/jni.dart" as jni;
   }
 }
 
-/// Generates the Dart class definition, type class, and the array extension
+/// Generates the Dart class definition, type class, and the array extension.
 class _ClassGenerator extends Visitor<ClassDecl, void> {
   final Config config;
   final StringSink s;
@@ -303,11 +302,11 @@ class _ClassGenerator extends Visitor<ClassDecl, void> {
     final isDartOnly =
         config.outputConfig.bindingsType == BindingsType.dartOnly;
 
-    // Docs
+    // Docs.
     s.write('/// from: ${node.binaryName}\n');
     node.javadoc?.accept(_DocGenerator(s, depth: 0));
 
-    // Class definition
+    // Class definition.
     final name = node.finalName;
     final superName = node.superclass!.accept(_TypeGenerator(resolver));
     final implClassName = '\$${name}Impl';
@@ -369,7 +368,7 @@ class $name$typeParamsDef extends $superName {
 ''');
     }
 
-    // Static TypeClass getter
+    // Static TypeClass getter.
     s.writeln(
         '  /// The type which includes information such as the signature of this class.');
     final typeClassName = node.typeClassName;
@@ -404,7 +403,7 @@ class $name$typeParamsDef extends $superName {
       method.accept(methodGenerator);
     }
 
-    // Experimental: Interface implementation
+    // Experimental: Interface implementation.
     if (node.declKind == DeclKind.interfaceKind &&
         (config.experiments?.contains(Experiment.interfaceImplementation) ??
             false)) {
@@ -495,7 +494,7 @@ class $name$typeParamsDef extends $superName {
   ''');
     }
 
-    // End of Class definition
+    // End of Class definition.
     s.writeln('}');
 
     // Experimental: Interface implementation
@@ -504,7 +503,7 @@ class $name$typeParamsDef extends $superName {
     if (node.declKind == DeclKind.interfaceKind &&
         (config.experiments?.contains(Experiment.interfaceImplementation) ??
             false)) {
-      // Abstract Impl class
+      // Abstract Impl class.
       final typeClassGetters = typeParams
           .map((typeParam) =>
               '$_jType<$_typeParamPrefix$typeParam> get $typeParam;')
@@ -533,7 +532,7 @@ abstract class $implClassName$typeParamsDef {
       }
       s.writeln('}');
 
-      // Concrete Impl class
+      // Concrete Impl class.
       // This is for passing closures instead of implementing the class.
       final concreteCtorArgs = _encloseIfNotEmpty(
         '{',
@@ -575,7 +574,7 @@ class _$implClassName$typeParamsDef implements $implClassName$typeParamsCall {
       }
       s.writeln('}');
     }
-    // TypeClass definition
+    // TypeClass definition.
     final typeClassesCall =
         typeParams.map((typeParam) => '$typeParam,').join(_newLine(depth: 2));
     final signature = node.signature;
@@ -1083,10 +1082,10 @@ class _FieldGenerator extends Visitor<Field, void> {
       }
     }
 
-    // Accessors
+    // Accessors.
     (isCBased ? writeCAccessor : writeDartOnlyAccessor)(node);
 
-    // Getter docs
+    // Getter docs.
     writeDocs(node, writeDeleteInstructions: true);
 
     final name = node.finalName;
@@ -1098,7 +1097,7 @@ class _FieldGenerator extends Visitor<Field, void> {
     ));
     s.writeln(';\n');
     if (!node.isFinal) {
-      // Setter docs
+      // Setter docs.
       writeDocs(node, writeDeleteInstructions: true);
 
       s.write('${ifStatic}set $name($type value) => ');

--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -761,7 +761,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
     final innerTypeClass = node.type.accept(_TypeClassGenerator(
       resolver,
       isConst: false,
-      boxPrimitives: boxPrimitives,
+      boxPrimitives: false,
       typeVarFromMap: typeVarFromMap,
     ));
     final ifConst = innerTypeClass.canBeConst && isConst ? 'const ' : '';
@@ -781,7 +781,7 @@ class _TypeClassGenerator extends TypeVisitor<_TypeClass> {
     final definedTypeClasses = node.params.accept(_TypeClassGenerator(
       resolver,
       isConst: false,
-      boxPrimitives: boxPrimitives,
+      boxPrimitives: false,
       typeVarFromMap: typeVarFromMap,
     ));
 

--- a/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
@@ -2919,24 +2919,19 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     return _manyPrimitives(reference, a, b ? 1 : 0, c, d).long;
   }
 
-  /// Maps a specific port to the implemented methods.
-  static final Map<int, Map<String, Function>> _$methods = {};
-
-  /// Maps a specific port to the type parameters.
-  static final Map<int, Map<String, jni.JObjType>> _$types = {};
+  /// Maps a specific port to the implemented interface.
+  static final Map<int, $MyInterfaceImpl> _$impls = {};
 
   ReceivePort? _$p;
 
   static final Finalizer<ReceivePort> _$finalizer = Finalizer(($p) {
-    _$methods.remove($p.sendPort.nativePort);
-    _$types.remove($p.sendPort.nativePort);
+    _$impls.remove($p.sendPort.nativePort);
     $p.close();
   });
 
   @override
   void delete() {
-    _$methods.remove(_$p?.sendPort.nativePort);
-    _$types.remove(_$p?.sendPort.nativePort);
+    _$impls.remove(_$p?.sendPort.nativePort);
     _$p?.close();
     _$finalizer.detach(this);
     super.delete();
@@ -2970,13 +2965,13 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     final $d = $i.methodDescriptor.toDartString(deleteOriginal: true);
     final $a = $i.args;
     if ($d == r"voidCallback(Ljava/lang/String;)V") {
-      _$methods[$p]![$d]!(
+      _$impls[$p]!.voidCallback(
         $a[0].castTo(const jni.JStringType(), deleteOriginal: true),
       );
       return jni.nullptr;
     }
     if ($d == r"stringCallback(Ljava/lang/String;)Ljava/lang/String;") {
-      final $r = _$methods[$p]![$d]!(
+      final $r = _$impls[$p]!.stringCallback(
         $a[0].castTo(const jni.JStringType(), deleteOriginal: true),
       );
       return (($r as jni.JObject).castTo(const jni.JObjectType())
@@ -2984,15 +2979,15 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
           .reference;
     }
     if ($d == r"varCallback(Ljava/lang/Object;)Ljava/lang/Object;") {
-      final $r = _$methods[$p]![$d]!(
-        $a[0].castTo(_$types[$p]!["T"]!, deleteOriginal: true),
+      final $r = _$impls[$p]!.varCallback(
+        $a[0].castTo(_$impls[$p]!.T, deleteOriginal: true),
       );
       return (($r as jni.JObject).castTo(const jni.JObjectType())
             ..setAsDeleted())
           .reference;
     }
     if ($d == r"manyPrimitives(IZCD)J") {
-      final $r = _$methods[$p]![$d]!(
+      final $r = _$impls[$p]!.manyPrimitives(
         $a[0]
             .castTo(const jni.JIntegerType(), deleteOriginal: true)
             .intValue(deleteOriginal: true),
@@ -3011,16 +3006,12 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     return jni.nullptr;
   }
 
-  factory MyInterface.implement({
-    required jni.JObjType<$T> T,
-    required void Function(jni.JString s) voidCallback,
-    required jni.JString Function(jni.JString s) stringCallback,
-    required $T Function($T t) varCallback,
-    required int Function(int a, bool b, int c, double d) manyPrimitives,
-  }) {
+  factory MyInterface.implement(
+    $MyInterfaceImpl<$T> $impl,
+  ) {
     final $p = ReceivePort();
     final $x = MyInterface.fromRef(
-      T,
+      $impl.T,
       ProtectedJniExtensions.newPortProxy(
         r"com.github.dart_lang.jnigen.interfaces.MyInterface",
         $p,
@@ -3028,15 +3019,7 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
       ),
     ).._$p = $p;
     final $a = $p.sendPort.nativePort;
-    _$types[$a] = {};
-    _$methods[$a] = {};
-    _$types[$a]!["T"] = T;
-    _$methods[$a]![r"voidCallback(Ljava/lang/String;)V"] = voidCallback;
-    _$methods[$a]![r"stringCallback(Ljava/lang/String;)Ljava/lang/String;"] =
-        stringCallback;
-    _$methods[$a]![r"varCallback(Ljava/lang/Object;)Ljava/lang/Object;"] =
-        varCallback;
-    _$methods[$a]![r"manyPrimitives(IZCD)J"] = manyPrimitives;
+    _$impls[$a] = $impl;
     _$finalizer.attach($x, $p, detach: $x);
     $p.listen(($m) {
       final $i = $MethodInvocation.fromMessage($m);
@@ -3044,6 +3027,61 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
       ProtectedJniExtensions.returnResult($i.result, $r);
     });
     return $x;
+  }
+}
+
+abstract class $MyInterfaceImpl<$T extends jni.JObject> {
+  factory $MyInterfaceImpl({
+    required jni.JObjType<$T> T,
+    required void Function(jni.JString s) voidCallback,
+    required jni.JString Function(jni.JString s) stringCallback,
+    required $T Function($T t) varCallback,
+    required int Function(int a, bool b, int c, double d) manyPrimitives,
+  }) = _$MyInterfaceImpl;
+
+  jni.JObjType<$T> get T;
+
+  void voidCallback(jni.JString s);
+  jni.JString stringCallback(jni.JString s);
+  $T varCallback($T t);
+  int manyPrimitives(int a, bool b, int c, double d);
+}
+
+class _$MyInterfaceImpl<$T extends jni.JObject>
+    implements $MyInterfaceImpl<$T> {
+  _$MyInterfaceImpl({
+    required this.T,
+    required void Function(jni.JString s) voidCallback,
+    required jni.JString Function(jni.JString s) stringCallback,
+    required $T Function($T t) varCallback,
+    required int Function(int a, bool b, int c, double d) manyPrimitives,
+  })  : _voidCallback = voidCallback,
+        _stringCallback = stringCallback,
+        _varCallback = varCallback,
+        _manyPrimitives = manyPrimitives;
+
+  @override
+  final jni.JObjType<$T> T;
+
+  final void Function(jni.JString s) _voidCallback;
+  final jni.JString Function(jni.JString s) _stringCallback;
+  final $T Function($T t) _varCallback;
+  final int Function(int a, bool b, int c, double d) _manyPrimitives;
+
+  void voidCallback(jni.JString s) {
+    return _voidCallback(s);
+  }
+
+  jni.JString stringCallback(jni.JString s) {
+    return _stringCallback(s);
+  }
+
+  $T varCallback($T t) {
+    return _varCallback(t);
+  }
+
+  int manyPrimitives(int a, bool b, int c, double d) {
+    return _manyPrimitives(a, b, c, d);
   }
 }
 

--- a/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
@@ -2758,24 +2758,19 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
         [jni.JValueInt(a), b ? 1 : 0, jni.JValueChar(c), d]).long;
   }
 
-  /// Maps a specific port to the implemented methods.
-  static final Map<int, Map<String, Function>> _$methods = {};
-
-  /// Maps a specific port to the type parameters.
-  static final Map<int, Map<String, jni.JObjType>> _$types = {};
+  /// Maps a specific port to the implemented interface.
+  static final Map<int, $MyInterfaceImpl> _$impls = {};
 
   ReceivePort? _$p;
 
   static final Finalizer<ReceivePort> _$finalizer = Finalizer(($p) {
-    _$methods.remove($p.sendPort.nativePort);
-    _$types.remove($p.sendPort.nativePort);
+    _$impls.remove($p.sendPort.nativePort);
     $p.close();
   });
 
   @override
   void delete() {
-    _$methods.remove(_$p?.sendPort.nativePort);
-    _$types.remove(_$p?.sendPort.nativePort);
+    _$impls.remove(_$p?.sendPort.nativePort);
     _$p?.close();
     _$finalizer.detach(this);
     super.delete();
@@ -2809,13 +2804,13 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     final $d = $i.methodDescriptor.toDartString(deleteOriginal: true);
     final $a = $i.args;
     if ($d == r"voidCallback(Ljava/lang/String;)V") {
-      _$methods[$p]![$d]!(
+      _$impls[$p]!.voidCallback(
         $a[0].castTo(const jni.JStringType(), deleteOriginal: true),
       );
       return jni.nullptr;
     }
     if ($d == r"stringCallback(Ljava/lang/String;)Ljava/lang/String;") {
-      final $r = _$methods[$p]![$d]!(
+      final $r = _$impls[$p]!.stringCallback(
         $a[0].castTo(const jni.JStringType(), deleteOriginal: true),
       );
       return (($r as jni.JObject).castTo(const jni.JObjectType())
@@ -2823,15 +2818,15 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
           .reference;
     }
     if ($d == r"varCallback(Ljava/lang/Object;)Ljava/lang/Object;") {
-      final $r = _$methods[$p]![$d]!(
-        $a[0].castTo(_$types[$p]!["T"]!, deleteOriginal: true),
+      final $r = _$impls[$p]!.varCallback(
+        $a[0].castTo(_$impls[$p]!.T, deleteOriginal: true),
       );
       return (($r as jni.JObject).castTo(const jni.JObjectType())
             ..setAsDeleted())
           .reference;
     }
     if ($d == r"manyPrimitives(IZCD)J") {
-      final $r = _$methods[$p]![$d]!(
+      final $r = _$impls[$p]!.manyPrimitives(
         $a[0]
             .castTo(const jni.JIntegerType(), deleteOriginal: true)
             .intValue(deleteOriginal: true),
@@ -2850,16 +2845,12 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     return jni.nullptr;
   }
 
-  factory MyInterface.implement({
-    required jni.JObjType<$T> T,
-    required void Function(jni.JString s) voidCallback,
-    required jni.JString Function(jni.JString s) stringCallback,
-    required $T Function($T t) varCallback,
-    required int Function(int a, bool b, int c, double d) manyPrimitives,
-  }) {
+  factory MyInterface.implement(
+    $MyInterfaceImpl<$T> $impl,
+  ) {
     final $p = ReceivePort();
     final $x = MyInterface.fromRef(
-      T,
+      $impl.T,
       ProtectedJniExtensions.newPortProxy(
         r"com.github.dart_lang.jnigen.interfaces.MyInterface",
         $p,
@@ -2867,15 +2858,7 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
       ),
     ).._$p = $p;
     final $a = $p.sendPort.nativePort;
-    _$types[$a] = {};
-    _$methods[$a] = {};
-    _$types[$a]!["T"] = T;
-    _$methods[$a]![r"voidCallback(Ljava/lang/String;)V"] = voidCallback;
-    _$methods[$a]![r"stringCallback(Ljava/lang/String;)Ljava/lang/String;"] =
-        stringCallback;
-    _$methods[$a]![r"varCallback(Ljava/lang/Object;)Ljava/lang/Object;"] =
-        varCallback;
-    _$methods[$a]![r"manyPrimitives(IZCD)J"] = manyPrimitives;
+    _$impls[$a] = $impl;
     _$finalizer.attach($x, $p, detach: $x);
     $p.listen(($m) {
       final $i = $MethodInvocation.fromMessage($m);
@@ -2883,6 +2866,61 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
       ProtectedJniExtensions.returnResult($i.result, $r);
     });
     return $x;
+  }
+}
+
+abstract class $MyInterfaceImpl<$T extends jni.JObject> {
+  factory $MyInterfaceImpl({
+    required jni.JObjType<$T> T,
+    required void Function(jni.JString s) voidCallback,
+    required jni.JString Function(jni.JString s) stringCallback,
+    required $T Function($T t) varCallback,
+    required int Function(int a, bool b, int c, double d) manyPrimitives,
+  }) = _$MyInterfaceImpl;
+
+  jni.JObjType<$T> get T;
+
+  void voidCallback(jni.JString s);
+  jni.JString stringCallback(jni.JString s);
+  $T varCallback($T t);
+  int manyPrimitives(int a, bool b, int c, double d);
+}
+
+class _$MyInterfaceImpl<$T extends jni.JObject>
+    implements $MyInterfaceImpl<$T> {
+  _$MyInterfaceImpl({
+    required this.T,
+    required void Function(jni.JString s) voidCallback,
+    required jni.JString Function(jni.JString s) stringCallback,
+    required $T Function($T t) varCallback,
+    required int Function(int a, bool b, int c, double d) manyPrimitives,
+  })  : _voidCallback = voidCallback,
+        _stringCallback = stringCallback,
+        _varCallback = varCallback,
+        _manyPrimitives = manyPrimitives;
+
+  @override
+  final jni.JObjType<$T> T;
+
+  final void Function(jni.JString s) _voidCallback;
+  final jni.JString Function(jni.JString s) _stringCallback;
+  final $T Function($T t) _varCallback;
+  final int Function(int a, bool b, int c, double d) _manyPrimitives;
+
+  void voidCallback(jni.JString s) {
+    return _voidCallback(s);
+  }
+
+  jni.JString stringCallback(jni.JString s) {
+    return _stringCallback(s);
+  }
+
+  $T varCallback($T t) {
+    return _varCallback(t);
+  }
+
+  int manyPrimitives(int a, bool b, int c, double d) {
+    return _manyPrimitives(a, b, c, d);
   }
 }
 

--- a/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -543,28 +543,31 @@ void registerTests(String groupName, TestRunnerCallback test) {
         // or `self` argument for each one of the callbacks.
         late final MyInterface<JInteger> myInterface;
         myInterface = MyInterface.implement(
-          voidCallback: (s) {
-            voidCallbackResult.complete(s);
-          },
-          stringCallback: (s) {
-            return (s.toDartString(deleteOriginal: true) * 2).toJString();
-          },
-          varCallback: (JInteger t) {
-            final result = (t.intValue(deleteOriginal: true) * 2).toJInteger();
-            varCallbackResult.complete(result);
-            return result;
-          },
-          manyPrimitives: (a, b, c, d) {
-            if (b) {
-              final result = a + c + d.toInt();
-              manyPrimitivesResult.complete(result);
+          $MyInterfaceImpl(
+            voidCallback: (s) {
+              voidCallbackResult.complete(s);
+            },
+            stringCallback: (s) {
+              return (s.toDartString(deleteOriginal: true) * 2).toJString();
+            },
+            varCallback: (JInteger t) {
+              final result =
+                  (t.intValue(deleteOriginal: true) * 2).toJInteger();
+              varCallbackResult.complete(result);
               return result;
-            } else {
-              // Call self, add to [a] when [b] is false and change b to true.
-              return myInterface.manyPrimitives(a + 1, true, c, d);
-            }
-          },
-          T: JInteger.type,
+            },
+            manyPrimitives: (a, b, c, d) {
+              if (b) {
+                final result = a + c + d.toInt();
+                manyPrimitivesResult.complete(result);
+                return result;
+              } else {
+                // Call self, add to [a] when [b] is false and change b to true.
+                return myInterface.manyPrimitives(a + 1, true, c, d);
+              }
+            },
+            T: JInteger.type,
+          ),
         );
         // [stringCallback] is going to be called first using [s].
         // The result of it is going to be used as the argument for


### PR DESCRIPTION
Creating two extra classes for each interface when the `interface_implementation` experiment is enabled:

1. `$<Interface>Impl`: This abstract (interface can be added after upgrade to Dart 3 – #334) class can be implemented and then used as an argument for `<Interface>.implement`, instead of passing closures one by one.
2. `_$<Interface>Impl`: This class is a concrete implementation of the previous which gets individual closures like before. This is private and its constructor is exposed through the unnamed factory for `$<Interface>Impl`. This is useful for creating a quick lambda-like class.

Although we still have not explored the direct extension of the Java object, namings, etc. This PR makes the code cleaner that what it currently is and gives users the ability to neatly organize their code without sacrificing the convenience of creating inline classes.

I will create a design doc exploring the other parts of the design. We should also have a way to make `void` methods non-blocking. Something like `bool get $<method-name>Blocking;` that can be set to either `true` or `false`.