### PR TITLE
feat: ability to specify dep type

### DIFF
--- a/jnigen/bin/download_maven_jars.dart
+++ b/jnigen/bin/download_maven_jars.dart
@@ -14,10 +14,12 @@ void main(List<String> args) async {
   final config = Config.parseArgs(args);
   final mavenDownloads = config.mavenDownloads;
   if (mavenDownloads != null) {
+    stdout.writeln(mavenDownloads.repos.length);
+    stdout.writeAll(mavenDownloads.repos);
     await MavenTools.downloadMavenJars(
         MavenTools.deps(mavenDownloads.jarOnlyDeps + mavenDownloads.sourceDeps),
         mavenDownloads.jarDir,
-        repos: mavenDownloads.repos);
+        repos: MavenTools.repos(mavenDownloads.repos));
     await Directory(mavenDownloads.jarDir)
         .list()
         .map((entry) => entry.path)

--- a/jnigen/bin/download_maven_jars.dart
+++ b/jnigen/bin/download_maven_jars.dart
@@ -16,7 +16,8 @@ void main(List<String> args) async {
   if (mavenDownloads != null) {
     await MavenTools.downloadMavenJars(
         MavenTools.deps(mavenDownloads.jarOnlyDeps + mavenDownloads.sourceDeps),
-        mavenDownloads.jarDir);
+        mavenDownloads.jarDir,
+        repos: mavenDownloads.repos);
     await Directory(mavenDownloads.jarDir)
         .list()
         .map((entry) => entry.path)

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -9,7 +9,6 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
-import '../../tools.dart';
 import '../elements/elements.dart';
 import '../logging/logging.dart';
 import '../util/find_package.dart';
@@ -46,7 +45,7 @@ class MavenDownloads {
   String sourceDir;
   List<String> jarOnlyDeps;
   String jarDir;
-  List<MavenRepository> repos;
+  List<String> repos;
 }
 
 /// Configuration for Android SDK sources and stub JAR files.
@@ -613,7 +612,7 @@ class Config {
               jarOnlyDeps: prov.getStringList(_Props.jarOnlyDeps) ?? const [],
               jarDir: prov.getPath(_Props.mavenJarDir)?.toFilePath() ??
                   resolveFromConfigRoot(MavenDownloads.defaultMavenJarDir),
-            )
+              repos: prov.getStringList(_Props.repos) ?? const [])
           : null,
       androidSdkConfig: prov.hasValue(_Props.androidSdkConfig)
           ? AndroidSdkConfig(
@@ -688,6 +687,7 @@ class _Props {
   static const mavenSourceDir = '$mavenDownloads.source_dir';
   static const jarOnlyDeps = '$mavenDownloads.jar_only_deps';
   static const mavenJarDir = '$mavenDownloads.jar_dir';
+  static const repos = '$mavenDownloads.repos';
 
   static const androidSdkConfig = 'android_sdk_config';
   static const androidSdkRoot = '$androidSdkConfig.sdk_root';

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -9,6 +9,7 @@ import 'package:path/path.dart' as p;
 import 'package:pub_semver/pub_semver.dart';
 import 'package:yaml/yaml.dart';
 
+import '../../tools.dart';
 import '../elements/elements.dart';
 import '../logging/logging.dart';
 import '../util/find_package.dart';
@@ -34,17 +35,18 @@ class MavenDownloads {
   static const defaultMavenSourceDir = 'mvn_java';
   static const defaultMavenJarDir = 'mvn_jar';
 
-  MavenDownloads({
-    this.sourceDeps = const [],
-    // ASK: Should this be changed to a gitignore'd directory like build ?
-    this.sourceDir = defaultMavenSourceDir,
-    this.jarOnlyDeps = const [],
-    this.jarDir = defaultMavenJarDir,
-  });
+  MavenDownloads(
+      {this.sourceDeps = const [],
+      // ASK: Should this be changed to a gitignore'd directory like build ?
+      this.sourceDir = defaultMavenSourceDir,
+      this.jarOnlyDeps = const [],
+      this.jarDir = defaultMavenJarDir,
+      this.repos = const []});
   List<String> sourceDeps;
   String sourceDir;
   List<String> jarOnlyDeps;
   String jarDir;
+  List<MavenRepository> repos;
 }
 
 /// Configuration for Android SDK sources and stub JAR files.

--- a/jnigen/lib/src/summary/summary.dart
+++ b/jnigen/lib/src/summary/summary.dart
@@ -120,13 +120,13 @@ Future<Classes> getSummary(Config config) async {
     await Directory(sourcePath).create(recursive: true);
     await MavenTools.downloadMavenSources(
         MavenTools.deps(mavenDl.sourceDeps), sourcePath,
-        repos: mavenDl.repos);
+        repos: MavenTools.repos(mavenDl.repos));
     extraSources.add(Uri.directory(sourcePath));
     final jarPath = mavenDl.jarDir;
     await Directory(jarPath).create(recursive: true);
     await MavenTools.downloadMavenJars(
         MavenTools.deps(mavenDl.sourceDeps + mavenDl.jarOnlyDeps), jarPath,
-        repos: mavenDl.repos);
+        repos: MavenTools.repos(mavenDl.repos));
     extraJars.addAll(await Directory(jarPath)
         .list()
         .where((entry) => entry.path.endsWith('.jar'))

--- a/jnigen/lib/src/summary/summary.dart
+++ b/jnigen/lib/src/summary/summary.dart
@@ -119,12 +119,14 @@ Future<Classes> getSummary(Config config) async {
     final sourcePath = mavenDl.sourceDir;
     await Directory(sourcePath).create(recursive: true);
     await MavenTools.downloadMavenSources(
-        MavenTools.deps(mavenDl.sourceDeps), sourcePath);
+        MavenTools.deps(mavenDl.sourceDeps), sourcePath,
+        repos: mavenDl.repos);
     extraSources.add(Uri.directory(sourcePath));
     final jarPath = mavenDl.jarDir;
     await Directory(jarPath).create(recursive: true);
     await MavenTools.downloadMavenJars(
-        MavenTools.deps(mavenDl.sourceDeps + mavenDl.jarOnlyDeps), jarPath);
+        MavenTools.deps(mavenDl.sourceDeps + mavenDl.jarOnlyDeps), jarPath,
+        repos: mavenDl.repos);
     extraJars.addAll(await Directory(jarPath)
         .list()
         .where((entry) => entry.path.endsWith('.jar'))

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -42,6 +42,10 @@ class MavenTools {
   static List<MavenDependency> deps(List<String> depNames) =>
       depNames.map(MavenDependency.fromString).toList();
 
+  /// Create a list of [MavenRepository] objects from a list of strings.
+  static List<MavenRepository> repos(List<String> repos) =>
+      repos.map(MavenRepository.fromString).toList();
+
   /// Downloads and unpacks source files of [deps] into [targetDir].
   static Future<void> downloadMavenSources(
       List<MavenDependency> deps, String targetDir,
@@ -154,7 +158,7 @@ class MavenDependency {
       {this.otherTags = const {}});
   factory MavenDependency.fromString(String fullName) {
     final components = fullName.split(':');
-    if (components.length != 3) {
+    if (components.length < 3) {
       throw ArgumentError('invalid name for maven dependency: $fullName');
     }
     return MavenDependency(components[0], components[1], components[2]);
@@ -165,6 +169,13 @@ class MavenDependency {
 
 class MavenRepository {
   MavenRepository(this.id, this.name, this.url, {this.otherTags = const {}});
+  factory MavenRepository.fromString(String fullName) {
+    final components = fullName.split('|');
+    if (components.length < 3) {
+      throw ArgumentError('invalid maven repo: $fullName');
+    }
+    return MavenRepository(components[0], components[1], components[2]);
+  }
   String id, name, url;
   Map<String, String> otherTags;
 }

--- a/jnigen/lib/src/tools/maven_tools.dart
+++ b/jnigen/lib/src/tools/maven_tools.dart
@@ -96,6 +96,7 @@ class MavenTools {
         <groupId>${dep.groupID}</groupId>
         <artifactId>${dep.artifactID}</artifactId>
         <version>${dep.version}</version>
+        <type>${dep.type}</type>
         ${otherTags.toString()}
       </dependency>''');
     }
@@ -155,15 +156,20 @@ ${_getDepDecls(deps).join("\n")}
 
 class MavenDependency {
   MavenDependency(this.groupID, this.artifactID, this.version,
-      {this.otherTags = const {}});
+      {this.type = "jar", this.otherTags = const {}});
   factory MavenDependency.fromString(String fullName) {
     final components = fullName.split(':');
     if (components.length < 3) {
       throw ArgumentError('invalid name for maven dependency: $fullName');
     }
-    return MavenDependency(components[0], components[1], components[2]);
+    String? type;
+    try {
+      type = components[3];
+    } on IndexError {}
+    return MavenDependency(components[0], components[1], components[2],
+        type: type ?? "jar");
   }
-  String groupID, artifactID, version;
+  String groupID, artifactID, version, type;
   Map<String, String> otherTags;
 }
 


### PR DESCRIPTION
Ability to specify dependency type in the POM.

I need to download AAR deps in a plugin, I've not yet figured out how to include them in the classpath though.
(And I don't want to specify deps at the app module level, I'd like this plugin to be plug-and-play.)

Edit: this does work if I direct `example/`'s gradle to `mvn_jar` as a repo and specify the AAR dependency in the app module, but this isn't the best.