### PR TITLE
Remove class exclusion from test

### DIFF
--- a/jnigen/test/jackson_core_test/generate.dart
+++ b/jnigen/test/jackson_core_test/generate.dart
@@ -77,10 +77,6 @@ Config getConfig({
         ['com.fasterxml.jackson.core.base.ParserMinimalBase', 'CHAR_NULL'],
         ['com.fasterxml.jackson.core.io.UTF32Reader', 'NC'],
       ]),
-      // TODO(#159): Remove class exclusions.
-      classes: ClassNameFilter.exclude(
-        'com.fasterxml.jackson.core.JsonFactoryBuilder',
-      ),
     ),
     experiments: {Experiment.interfaceImplementation},
   );


### PR DESCRIPTION
This issue is fixed. Removing the class exclusion and todo comment.

closes dart-lang/native#693