### PR TITLE
Finalize interfaces in Java

### DIFF
--- a/jni/java/src/main/java/com/github/dart_lang/jni/PortCleaner.java
+++ b/jni/java/src/main/java/com/github/dart_lang/jni/PortCleaner.java
@@ -7,6 +7,9 @@ package com.github.dart_lang.jni;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
 
+/// A registry of Java objects with associated Dart resources that cleans up the
+/// resources after they get unreachable and collected by the garbage collector.
+///
 /// A simple alternative to [java.lang.ref.Cleaner] which is only available in
 /// Android API level 33+.
 class PortCleaner {

--- a/jni/java/src/main/java/com/github/dart_lang/jni/PortCleaner.java
+++ b/jni/java/src/main/java/com/github/dart_lang/jni/PortCleaner.java
@@ -1,0 +1,85 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+package com.github.dart_lang.jni;
+
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+
+/// A simple alternative to [java.lang.ref.Cleaner] which is only available in
+/// Android API level 33+.
+class PortCleaner {
+  static {
+    System.loadLibrary("dartjni");
+  }
+
+  private final ReferenceQueue<Object> queue = new ReferenceQueue<>();
+  private final PortPhantom list = new PortPhantom();
+
+  private class PortPhantom extends PhantomReference<Object> {
+    final long port;
+
+    /// Form a linked list.
+    PortPhantom prev = this, next = this;
+
+    PortPhantom(Object referent, long port) {
+      super(referent, queue);
+      this.port = port;
+      insert();
+    }
+
+    /// Only used for the head of the list.
+    PortPhantom() {
+      super(null, null);
+      this.port = 0;
+    }
+
+    void insert() {
+      synchronized (list) {
+        prev = list;
+        next = list.next;
+        next.prev = this;
+        list.next = this;
+      }
+    }
+
+    private void remove() {
+      synchronized (list) {
+        next.prev = prev;
+        prev.next = next;
+        prev = this;
+        next = this;
+      }
+    }
+  }
+
+  PortCleaner() {
+    // Only a single PortCleaner and therefore thread will be created.
+    Thread thread =
+        new Thread(
+            () -> {
+              while (true) {
+                try {
+                  PortPhantom portPhantom = (PortPhantom) queue.remove();
+                  portPhantom.remove();
+                  if (portPhantom.port != 0) {
+                    clean(portPhantom.port);
+                  }
+                } catch (Throwable e) {
+                  // Ignore.
+                }
+              }
+            },
+            "PortCleaner");
+    thread.setDaemon(true);
+    thread.start();
+  }
+
+  /// Registers [obj] to be cleaned up later by sending a signal through [port].
+  void register(Object obj, long port) {
+    new PortPhantom(obj, port);
+  }
+
+  private static native void clean(long port);
+}

--- a/jni/java/src/main/java/com/github/dart_lang/jni/PortProxy.java
+++ b/jni/java/src/main/java/com/github/dart_lang/jni/PortProxy.java
@@ -4,11 +4,27 @@
 
 package com.github.dart_lang.jni;
 
+import java.lang.ref.Cleaner;
 import java.lang.reflect.*;
 
 public class PortProxy implements InvocationHandler {
   static {
     System.loadLibrary("dartjni");
+  }
+
+  private static final Cleaner cleaner = Cleaner.create();
+
+  private static class SignalClean implements Runnable {
+    private final long port;
+
+    private SignalClean(long port) {
+      this.port = port;
+    }
+
+    @Override
+    public void run() {
+      _close(port);
+    }
   }
 
   private final long port;
@@ -23,48 +39,53 @@ public class PortProxy implements InvocationHandler {
 
   private static String getDescriptor(Method method) {
     StringBuilder descriptor = new StringBuilder();
-    descriptor.append(method.getName()).append("(");
+    descriptor.append(method.getName()).append('(');
     Class<?>[] parameterTypes = method.getParameterTypes();
     for (Class<?> paramType : parameterTypes) {
       appendType(descriptor, paramType);
     }
-    descriptor.append(")");
+    descriptor.append(')');
     appendType(descriptor, method.getReturnType());
     return descriptor.toString();
   }
 
   private static void appendType(StringBuilder descriptor, Class<?> type) {
     if (type == void.class) {
-      descriptor.append("V");
+      descriptor.append('V');
     } else if (type == boolean.class) {
-      descriptor.append("Z");
+      descriptor.append('Z');
     } else if (type == byte.class) {
-      descriptor.append("B");
+      descriptor.append('B');
     } else if (type == char.class) {
-      descriptor.append("C");
+      descriptor.append('C');
     } else if (type == short.class) {
-      descriptor.append("S");
+      descriptor.append('S');
     } else if (type == int.class) {
-      descriptor.append("I");
+      descriptor.append('I');
     } else if (type == long.class) {
-      descriptor.append("J");
+      descriptor.append('J');
     } else if (type == float.class) {
-      descriptor.append("F");
+      descriptor.append('F');
     } else if (type == double.class) {
-      descriptor.append("D");
+      descriptor.append('D');
     } else if (type.isArray()) {
       descriptor.append('[');
       appendType(descriptor, type.getComponentType());
     } else {
-      descriptor.append("L").append(type.getName().replace('.', '/')).append(";");
+      descriptor.append('L').append(type.getName().replace('.', '/')).append(';');
     }
   }
 
   public static Object newInstance(String binaryName, long port, long isolateId, long functionPtr)
       throws ClassNotFoundException {
     Class<?> clazz = Class.forName(binaryName);
-    return Proxy.newProxyInstance(
-        clazz.getClassLoader(), new Class[] {clazz}, new PortProxy(port, isolateId, functionPtr));
+    Object obj =
+        Proxy.newProxyInstance(
+            clazz.getClassLoader(),
+            new Class[] {clazz},
+            new PortProxy(port, isolateId, functionPtr));
+    cleaner.register(obj, new SignalClean(port));
+    return obj;
   }
 
   @Override
@@ -77,7 +98,7 @@ public class PortProxy implements InvocationHandler {
   /// Returns an array with two objects:
   /// [0]: The address of the result pointer used for the clean-up.
   /// [1]: The result of the invocation.
-  private native Object[] _invoke(
+  private static native Object[] _invoke(
       long port,
       long isolateId,
       long functionPtr,
@@ -85,5 +106,7 @@ public class PortProxy implements InvocationHandler {
       String methodDescriptor,
       Object[] args);
 
-  private native void _cleanUp(long resultPtr);
+  private static native void _cleanUp(long resultPtr);
+
+  private static native void _close(long port);
 }

--- a/jni/src/dartjni.c
+++ b/jni/src/dartjni.c
@@ -571,7 +571,7 @@ FFI_PLUGIN_EXPORT intptr_t InitDartApiDL(void* data) {
 
 JNIEXPORT void JNICALL
 Java_com_github_dart_1lang_jni_PortContinuation__1resumeWith(JNIEnv* env,
-                                                             jobject thiz,
+                                                             jclass clazz,
                                                              jlong port,
                                                              jobject result) {
   attach_thread();
@@ -643,7 +643,7 @@ jmethodID _m_Long_init = NULL;
 
 JNIEXPORT jobjectArray JNICALL
 Java_com_github_dart_1lang_jni_PortProxy__1invoke(JNIEnv* env,
-                                                  jobject thiz,
+                                                  jclass clazz,
                                                   jlong port,
                                                   jlong isolateId,
                                                   jlong functionPtr,
@@ -709,9 +709,18 @@ Java_com_github_dart_1lang_jni_PortProxy__1invoke(JNIEnv* env,
 
 JNIEXPORT void JNICALL
 Java_com_github_dart_1lang_jni_PortProxy__1cleanUp(JNIEnv* env,
-                                                   jobject thiz,
+                                                   jclass clazz,
                                                    jlong resultPtr) {
   CallbackResult* result = (CallbackResult*)resultPtr;
   (*env)->DeleteGlobalRef(env, result->object);
   free(result);
+}
+
+JNIEXPORT void JNICALL
+Java_com_github_dart_1lang_jni_PortProxy__1close(JNIEnv* env,
+                                                 jclass clazz,
+                                                 jlong port) {
+  Dart_CObject close_signal;
+  close_signal.type = Dart_CObject_kNull;
+  Dart_PostCObject_DL(port, &close_signal);
 }

--- a/jni/src/dartjni.c
+++ b/jni/src/dartjni.c
@@ -717,7 +717,7 @@ Java_com_github_dart_1lang_jni_PortProxy__1cleanUp(JNIEnv* env,
 }
 
 JNIEXPORT void JNICALL
-Java_com_github_dart_1lang_jni_PortProxy__1close(JNIEnv* env,
+Java_com_github_dart_1lang_jni_PortCleaner_clean(JNIEnv* env,
                                                  jclass clazz,
                                                  jlong port) {
   Dart_CObject close_signal;

--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -410,30 +410,18 @@ class $name$typeParamsDef extends $superName {
       s.write('''
   /// Maps a specific port to the implemented interface.
   static final Map<int, $implClassName> _\$impls = {};
+''');
+      s.write(r'''
+  ReceivePort? _$p;
 
-  ReceivePort? _\$p;
-
-  static final Finalizer<ReceivePort> _\$finalizer = Finalizer((\$p) {
-    _\$impls.remove(\$p.sendPort.nativePort);
-    \$p.close();
-  });
-
-  @override
-  void delete() {
-    _\$impls.remove(_\$p?.sendPort.nativePort);
-    _\$p?.close();
-    _\$finalizer.detach(this);
-    super.delete();
-  }
-
-  static jni.JObjectPtr _\$invoke(
+  static jni.JObjectPtr _$invoke(
     int port,
     jni.JObjectPtr descriptor,
     jni.JObjectPtr args,
   ) {
-    return _\$invokeMethod(
+    return _$invokeMethod(
       port,
-      \$MethodInvocation.fromAddresses(
+      $MethodInvocation.fromAddresses(
         0,
         descriptor.address,
         args.address,
@@ -445,14 +433,14 @@ class $name$typeParamsDef extends $superName {
           ffi.NativeFunction<
               jni.JObjectPtr Function(
                   ffi.Uint64, jni.JObjectPtr, jni.JObjectPtr)>>
-      _\$invokePointer = ffi.Pointer.fromFunction(_\$invoke);
+      _$invokePointer = ffi.Pointer.fromFunction(_$invoke);
 
-  static ffi.Pointer<ffi.Void> _\$invokeMethod(
-    int \$p,
-    \$MethodInvocation \$i,
+  static ffi.Pointer<ffi.Void> _$invokeMethod(
+    int $p,
+    $MethodInvocation $i,
   ) {
-    final \$d = \$i.methodDescriptor.toDartString(deleteOriginal: true);
-    final \$a = \$i.args;
+    final $d = $i.methodDescriptor.toDartString(deleteOriginal: true);
+    final $a = $i.args;
     ''');
       final proxyMethodIf = _InterfaceMethodIf(resolver, s);
       for (final method in node.methods) {
@@ -482,16 +470,25 @@ class $name$typeParamsDef extends $superName {
     final \$a = \$p.sendPort.nativePort; 
     _\$impls[\$a] = \$impl;
 ''');
-      s.write('''
-    _\$finalizer.attach(\$x, \$p, detach: \$x);
-    \$p.listen((\$m) {
-      final \$i = \$MethodInvocation.fromMessage(\$m);
-      final \$r = _\$invokeMethod(\$p.sendPort.nativePort, \$i);
-      ProtectedJniExtensions.returnResult(\$i.result, \$r);
+      s.write(r'''
+    $p.listen(($m) {
+      if ($m == null) {
+        _$impls.remove($p.sendPort.nativePort);
+        $p.close();
+        return;
+      }
+      final $i = $MethodInvocation.fromMessage($m);
+      final $r = _$invokeMethod($p.sendPort.nativePort, $i);
+      ProtectedJniExtensions.returnResult($i.result, $r);
     });
-    return \$x;
+    return $x;
   }
   ''');
+    }
+
+    // Writing any custom code provided for this class.
+    if (config.customClassBody?.containsKey(node.binaryName) ?? false) {
+      s.writeln(config.customClassBody![node.binaryName]);
     }
 
     // End of Class definition.

--- a/jnigen/lib/src/config/config_types.dart
+++ b/jnigen/lib/src/config/config_types.dart
@@ -325,6 +325,7 @@ class Config {
     this.sourcePath,
     this.classPath,
     this.preamble,
+    this.customClassBody,
     this.androidSdkConfig,
     this.mavenDownloads,
     this.summarizerOptions,
@@ -385,6 +386,12 @@ class Config {
 
   /// Call [importClasses] before using this.
   late final Map<String, ClassDecl> importedClasses;
+
+  /// Custom code that is added to the end of the class body with the specified
+  /// binary name.
+  ///
+  /// Used for testing package:jnigen.
+  final Map<String, String>? customClassBody;
 
   Future<void> importClasses() async {
     importedClasses = {};

--- a/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
@@ -3344,21 +3344,7 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
 
   /// Maps a specific port to the implemented interface.
   static final Map<int, $MyInterfaceImpl> _$impls = {};
-
   ReceivePort? _$p;
-
-  static final Finalizer<ReceivePort> _$finalizer = Finalizer(($p) {
-    _$impls.remove($p.sendPort.nativePort);
-    $p.close();
-  });
-
-  @override
-  void delete() {
-    _$impls.remove(_$p?.sendPort.nativePort);
-    _$p?.close();
-    _$finalizer.detach(this);
-    super.delete();
-  }
 
   static jni.JObjectPtr _$invoke(
     int port,
@@ -3439,14 +3425,19 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     ).._$p = $p;
     final $a = $p.sendPort.nativePort;
     _$impls[$a] = $impl;
-    _$finalizer.attach($x, $p, detach: $x);
     $p.listen(($m) {
+      if ($m == null) {
+        _$impls.remove($p.sendPort.nativePort);
+        $p.close();
+        return;
+      }
       final $i = $MethodInvocation.fromMessage($m);
       final $r = _$invokeMethod($p.sendPort.nativePort, $i);
       ProtectedJniExtensions.returnResult($i.result, $r);
     });
     return $x;
   }
+  static Map<int, $MyInterfaceImpl> get $impls => _$impls;
 }
 
 abstract class $MyInterfaceImpl<$T extends jni.JObject> {

--- a/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
@@ -3153,21 +3153,7 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
 
   /// Maps a specific port to the implemented interface.
   static final Map<int, $MyInterfaceImpl> _$impls = {};
-
   ReceivePort? _$p;
-
-  static final Finalizer<ReceivePort> _$finalizer = Finalizer(($p) {
-    _$impls.remove($p.sendPort.nativePort);
-    $p.close();
-  });
-
-  @override
-  void delete() {
-    _$impls.remove(_$p?.sendPort.nativePort);
-    _$p?.close();
-    _$finalizer.detach(this);
-    super.delete();
-  }
 
   static jni.JObjectPtr _$invoke(
     int port,
@@ -3248,14 +3234,19 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
     ).._$p = $p;
     final $a = $p.sendPort.nativePort;
     _$impls[$a] = $impl;
-    _$finalizer.attach($x, $p, detach: $x);
     $p.listen(($m) {
+      if ($m == null) {
+        _$impls.remove($p.sendPort.nativePort);
+        $p.close();
+        return;
+      }
       final $i = $MethodInvocation.fromMessage($m);
       final $r = _$invokeMethod($p.sendPort.nativePort, $i);
       ProtectedJniExtensions.returnResult($i.result, $r);
     });
     return $x;
   }
+  static Map<int, $MyInterfaceImpl> get $impls => _$impls;
 }
 
 abstract class $MyInterfaceImpl<$T extends jni.JObject> {

--- a/jnigen/test/simple_package_test/generate.dart
+++ b/jnigen/test/simple_package_test/generate.dart
@@ -64,6 +64,11 @@ Config getConfig([BindingsType bindingsType = BindingsType.cBased]) {
       'com.github.dart_lang.jnigen.annotations',
     ],
     logLevel: Level.INFO,
+    customClassBody: {
+      'com.github.dart_lang.jnigen.interfaces.MyInterface': r'''
+  static Map<int, $MyInterfaceImpl> get $impls => _$impls;
+'''
+    },
     outputConfig: OutputConfig(
       bindingsType: bindingsType,
       cConfig: CCodeOutputConfig(

--- a/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -605,7 +605,7 @@ void registerTests(String groupName, TestRunnerCallback test) {
         myInterface.delete();
         // Running System.gc() and waiting.
         _runJavaGC();
-        for (var i = 0; i < 6; ++i) {
+        for (var i = 0; i < 8; ++i) {
           await Future<void>.delayed(Duration(milliseconds: (1 << i) * 100));
           if (MyInterface.$impls.isEmpty) {
             break;


### PR DESCRIPTION
closes #366.

Using a Java cleaner to signal Dart to clean up the resources.