### PR TITLE
Remove APK builds from windows minimal CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -248,12 +248,6 @@ jobs:
       - run: Add-Content $env:GITHUB_PATH "$env:JAVA_HOME\bin\server"
       - run: dart pub get
       - run: dart run jnigen:setup
-      - name: build in_app_java APK
-        run: flutter build apk --target-platform=android-arm64
-        working-directory: ./jnigen/example/in_app_java
-      - name: build notification_plugin example APK
-        run: flutter build apk --target-platform=android-arm64
-        working-directory: ./jnigen/example/notification_plugin/example
       - name: Build summarizer
         run: dart run jnigen:setup
       - name: Generate runtime tests

--- a/jnigen/test/descriptor_test.dart
+++ b/jnigen/test/descriptor_test.dart
@@ -22,7 +22,7 @@ void main() {
     ('jackson_core', jackson_core_test.getConfig),
   ]) {
     test('Method descriptor generation for $name',
-        timeout: const Timeout.factor(2), () async {
+        timeout: const Timeout.factor(3), () async {
       final config = getConfig();
       config.summarizerOptions =
           SummarizerOptions(backend: SummarizerBackend.asm);

--- a/jnigen/test/descriptor_test.dart
+++ b/jnigen/test/descriptor_test.dart
@@ -16,14 +16,13 @@ import 'test_util/test_util.dart';
 
 void main() {
   checkLocallyBuiltDependencies();
-  test('Method descriptor generation', timeout: const Timeout.factor(3),
-      () async {
-    final configGetters = [
-      simple_package_test.getConfig,
-      kotlin_test.getConfig,
-      jackson_core_test.getConfig
-    ];
-    for (final getConfig in configGetters) {
+  for (final (name, getConfig) in [
+    ('simple_package', simple_package_test.getConfig),
+    ('kotlin', kotlin_test.getConfig),
+    ('jackson_core', jackson_core_test.getConfig),
+  ]) {
+    test('Method descriptor generation for $name',
+        timeout: const Timeout.factor(2), () async {
       final config = getConfig();
       config.summarizerOptions =
           SummarizerOptions(backend: SummarizerBackend.asm);
@@ -38,6 +37,6 @@ void main() {
           expect(method.descriptor, method.accept(methodDescriptor));
         }
       }
-    }
-  });
+    });
+  }
 }

--- a/jnigen/test/simple_package_test/runtime_test_registrant.dart
+++ b/jnigen/test/simple_package_test/runtime_test_registrant.dart
@@ -17,8 +17,16 @@ const fpDelta = 0.001;
 const trillion = 1024 * 1024 * 1024 * 1024;
 
 void _runJavaGC() {
-  final system = Jni.findJClass('java/lang/System');
-  system.callStaticMethodByName<void>('gc', '()V', []);
+  final managementFactory =
+      Jni.findJClass('java/lang/management/ManagementFactory');
+  final bean = managementFactory.callStaticMethodByName<JObject>(
+      'getRuntimeMXBean', '()Ljava/lang/management/RuntimeMXBean;', []);
+  final pid = bean.callMethodByName<int>('getPid', '()J', []);
+  ProcessResult result;
+  do {
+    sleep(const Duration(milliseconds: 100));
+    result = Process.runSync('jcmd', [pid.toString(), 'GC.run']);
+  } while (result.exitCode != 0);
 }
 
 void registerTests(String groupName, TestRunnerCallback test) {


### PR DESCRIPTION
Somehow building APKs on windows is really slow. macOS minimal tests don't have the apk build, it's not really necessary to build the APKs in windows as the build system relies on Gradle and Flutter not something jnigen specific.

We already have tests for building Windows Flutter apps.