### PR TITLE
Add correct cast to interface method invocation

### DIFF
--- a/jnigen/CHANGELOG.md
+++ b/jnigen/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1-wip
+* Added an explicit cast in generated `<Interface>.implement` code to allow `dart analyze` to pass when `strict-casts` is set.
+
 ## 0.6.0
 * **Breaking Change** ([#131](https://github.com/dart-lang/jnigen/issues/131)): Renamed `delete*` to `release*`.
 * **Breaking Change** ([#354](https://github.com/dart-lang/jnigen/issues/354)): Renamed constructors from `ctor1`, `ctor2`, ... to `new1`, `new2`, ...

--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -479,7 +479,7 @@ class $name$typeParamsDef extends $superName {
         \$p.close();
         return;
       }
-      final \$i = \$MethodInvocation.fromMessage(\$m);
+      final \$i = \$MethodInvocation.fromMessage(\$m as List<dynamic>);
       final \$r = _\$invokeMethod(\$p.sendPort.nativePort, \$i);
       $_protectedExtension.returnResult(\$i.result, \$r);
     });

--- a/jnigen/pubspec.yaml
+++ b/jnigen/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: jnigen
 description: A Dart bindings generator for Java and Kotlin that uses JNI under the hood to interop with Java virtual machine.
-version: 0.6.0
+version: 0.6.1-wip
 repository: https://github.com/dart-lang/jnigen/tree/main/jnigen
 
 environment:

--- a/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
@@ -3435,7 +3435,7 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
         $p.close();
         return;
       }
-      final $i = $MethodInvocation.fromMessage($m);
+      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
       final $r = _$invokeMethod($p.sendPort.nativePort, $i);
       ProtectedJniExtensions.returnResult($i.result, $r);
     });
@@ -3733,7 +3733,7 @@ class MyRunnable extends jni.JObject {
         $p.close();
         return;
       }
-      final $i = $MethodInvocation.fromMessage($m);
+      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
       final $r = _$invokeMethod($p.sendPort.nativePort, $i);
       ProtectedJniExtensions.returnResult($i.result, $r);
     });

--- a/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
@@ -3244,7 +3244,7 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
         $p.close();
         return;
       }
-      final $i = $MethodInvocation.fromMessage($m);
+      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
       final $r = _$invokeMethod($p.sendPort.nativePort, $i);
       ProtectedJniExtensions.returnResult($i.result, $r);
     });
@@ -3540,7 +3540,7 @@ class MyRunnable extends jni.JObject {
         $p.close();
         return;
       }
-      final $i = $MethodInvocation.fromMessage($m);
+      final $i = $MethodInvocation.fromMessage($m as List<dynamic>);
       final $r = _$invokeMethod($p.sendPort.nativePort, $i);
       ProtectedJniExtensions.returnResult($i.result, $r);
     });


### PR DESCRIPTION
Modifies the generated code for `<Interface>.implement(...)` to include a type cast for the call to `$MethodInvocation.fromMessage` - this is required when strict type checking analysis is enabled.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
