### PR TITLE
WIP: Use `super.reference` in `fromRef` constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ final ffi.Pointer<T> Function<T extends ffi.NativeType>(String sym) jniLookup =
 
 /// from: com.example.in_app_java.AndroidUtils
 class AndroidUtils extends jni.JObject {
-  AndroidUtils.fromRef(ffi.Pointer<ffi.Void> ref) : super.fromRef(ref);
+  AndroidUtils.fromRef(super.reference) : super.fromRef();
 
   static final _showToast = jniLookup<
           ffi.NativeFunction<

--- a/jni/lib/src/jarray.dart
+++ b/jni/lib/src/jarray.dart
@@ -54,8 +54,7 @@ class JArray<E> extends JObject {
       JArrayType(innerType);
 
   /// Construct a new [JArray] with [reference] as its underlying reference.
-  JArray.fromRef(this.elementType, JArrayPtr reference)
-      : super.fromRef(reference);
+  JArray.fromRef(this.elementType, super.reference) : super.fromRef();
 
   /// Creates a [JArray] of the given length from the given [type].
   ///

--- a/jni/lib/src/jobject.dart
+++ b/jni/lib/src/jobject.dart
@@ -169,7 +169,7 @@ class JObject extends JReference {
   static const JObjType<JObject> type = JObjectType();
 
   /// Construct a new [JObject] with [reference] as its underlying reference.
-  JObject.fromRef(JObjectPtr reference) : super.fromRef(reference);
+  JObject.fromRef(super.reference) : super.fromRef();
 
   JClass? _jClass;
 
@@ -351,7 +351,7 @@ class JObject extends JReference {
 /// A high level wrapper over a JNI class reference.
 class JClass extends JReference {
   /// Construct a new [JClass] with [reference] as its underlying reference.
-  JClass.fromRef(JObjectPtr reference) : super.fromRef(reference);
+  JClass.fromRef(super.reference) : super.fromRef();
 
   /// Get [JFieldIDPtr] of static field [fieldName] with [signature].
   JFieldIDPtr getStaticFieldID(String fieldName, String signature) {

--- a/jni/lib/src/lang/jboolean.dart
+++ b/jni/lib/src/lang/jboolean.dart
@@ -38,9 +38,7 @@ class JBoolean extends JObject {
   // ignore: overridden_fields
   late final JObjType<JBoolean> $type = type;
 
-  JBoolean.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JBoolean.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JBooleanType();

--- a/jni/lib/src/lang/jbyte.dart
+++ b/jni/lib/src/lang/jbyte.dart
@@ -38,9 +38,7 @@ class JByte extends JNumber {
   // ignore: overridden_fields
   late final JObjType<JByte> $type = type;
 
-  JByte.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JByte.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JByteType();

--- a/jni/lib/src/lang/jcharacter.dart
+++ b/jni/lib/src/lang/jcharacter.dart
@@ -35,9 +35,7 @@ class JCharacter extends JObject {
   // ignore: overridden_fields
   late final JObjType<JCharacter> $type = type;
 
-  JCharacter.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JCharacter.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JCharacterType();

--- a/jni/lib/src/lang/jdouble.dart
+++ b/jni/lib/src/lang/jdouble.dart
@@ -37,9 +37,7 @@ class JDouble extends JNumber {
   // ignore: overridden_fields
   late final JObjType<JDouble> $type = type;
 
-  JDouble.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JDouble.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JDoubleType();

--- a/jni/lib/src/lang/jfloat.dart
+++ b/jni/lib/src/lang/jfloat.dart
@@ -38,9 +38,7 @@ class JFloat extends JNumber {
   // ignore: overridden_fields
   late final JObjType<JFloat> $type = type;
 
-  JFloat.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JFloat.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JFloatType();

--- a/jni/lib/src/lang/jinteger.dart
+++ b/jni/lib/src/lang/jinteger.dart
@@ -38,9 +38,7 @@ class JInteger extends JNumber {
   // ignore: overridden_fields
   late final JObjType<JInteger> $type = type;
 
-  JInteger.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JInteger.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JIntegerType();

--- a/jni/lib/src/lang/jlong.dart
+++ b/jni/lib/src/lang/jlong.dart
@@ -37,9 +37,7 @@ class JLong extends JNumber {
   // ignore: overridden_fields
   late final JObjType<JLong> $type = type;
 
-  JLong.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JLong.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JLongType();

--- a/jni/lib/src/lang/jnumber.dart
+++ b/jni/lib/src/lang/jnumber.dart
@@ -46,9 +46,7 @@ class JNumber extends JObject {
   // ignore: overridden_fields
   late final JObjType<JNumber> $type = type;
 
-  JNumber.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JNumber.fromRef(super.reference) : super.fromRef();
 
   static final _class = Jni.findJClass(r"java/lang/Number");
 

--- a/jni/lib/src/lang/jshort.dart
+++ b/jni/lib/src/lang/jshort.dart
@@ -38,9 +38,7 @@ class JShort extends JNumber {
   // ignore: overridden_fields
   late final JObjType<JShort> $type = type;
 
-  JShort.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JShort.fromRef(super.reference) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = JShortType();

--- a/jni/lib/src/lang/jstring.dart
+++ b/jni/lib/src/lang/jstring.dart
@@ -9,7 +9,6 @@ import 'package:jni/src/jreference.dart';
 
 import '../jni.dart';
 import '../jobject.dart';
-import '../third_party/generated_bindings.dart';
 import '../types.dart';
 
 final class JStringType extends JObjType<JString> {
@@ -45,7 +44,7 @@ class JString extends JObject {
   static const JObjType<JString> type = JStringType();
 
   /// Construct a new [JString] with [reference] as its underlying reference.
-  JString.fromRef(JStringPtr reference) : super.fromRef(reference);
+  JString.fromRef(super.reference) : super.fromRef();
 
   /// The number of Unicode characters in this Java string.
   int get length => Jni.env.GetStringLength(reference);

--- a/jni/lib/src/nio/jbuffer.dart
+++ b/jni/lib/src/nio/jbuffer.dart
@@ -49,9 +49,7 @@ class JBuffer extends JObject {
   // ignore: overridden_fields
   late final JObjType<JBuffer> $type = type;
 
-  JBuffer.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JBuffer.fromRef(super.reference) : super.fromRef();
 
   static final _class = Jni.findJClass(r"java/nio/Buffer");
 

--- a/jni/lib/src/nio/jbyte_buffer.dart
+++ b/jni/lib/src/nio/jbyte_buffer.dart
@@ -92,9 +92,7 @@ class JByteBuffer extends JBuffer {
   // ignore: overridden_fields
   late final JObjType<JByteBuffer> $type = type;
 
-  JByteBuffer.fromRef(
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+  JByteBuffer.fromRef(super.reference) : super.fromRef();
 
   static final _class = Jni.findJClass(r"java/nio/ByteBuffer");
 

--- a/jni/lib/src/util/jiterator.dart
+++ b/jni/lib/src/util/jiterator.dart
@@ -47,8 +47,8 @@ class JIterator<$E extends JObject> extends JObject implements Iterator<$E> {
 
   JIterator.fromRef(
     this.E,
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = Jni.findJClass(r"java/util/Iterator");
 

--- a/jni/lib/src/util/jlist.dart
+++ b/jni/lib/src/util/jlist.dart
@@ -52,8 +52,8 @@ class JList<$E extends JObject> extends JObject with ListMixin<$E> {
 
   JList.fromRef(
     this.E,
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = Jni.findJClass(r"java/util/List");
 

--- a/jni/lib/src/util/jmap.dart
+++ b/jni/lib/src/util/jmap.dart
@@ -57,8 +57,8 @@ class JMap<$K extends JObject, $V extends JObject> extends JObject
   JMap.fromRef(
     this.K,
     this.V,
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = Jni.findJClass(r"java/util/Map");
 

--- a/jni/lib/src/util/jset.dart
+++ b/jni/lib/src/util/jset.dart
@@ -51,8 +51,8 @@ class JSet<$E extends JObject> extends JObject with SetMixin<$E> {
 
   JSet.fromRef(
     this.E,
-    JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = Jni.findJClass(r"java/util/Set");
 

--- a/jnigen/example/in_app_java/lib/android_utils.dart
+++ b/jnigen/example/in_app_java/lib/android_utils.dart
@@ -32,8 +32,8 @@ class AndroidUtils extends jni.JObject {
   late final jni.JObjType<AndroidUtils> $type = type;
 
   AndroidUtils.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $AndroidUtilsType();
@@ -134,8 +134,8 @@ class EmojiCompat extends jni.JObject {
   late final jni.JObjType<EmojiCompat> $type = type;
 
   EmojiCompat.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompatType();
@@ -1061,8 +1061,8 @@ class EmojiCompat_Config extends jni.JObject {
   late final jni.JObjType<EmojiCompat_Config> $type = type;
 
   EmojiCompat_Config.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_ConfigType();
@@ -1396,8 +1396,8 @@ class EmojiCompat_MetadataRepoLoaderCallback extends jni.JObject {
   late final jni.JObjType<EmojiCompat_MetadataRepoLoaderCallback> $type = type;
 
   EmojiCompat_MetadataRepoLoaderCallback.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_MetadataRepoLoaderCallbackType();
@@ -1486,8 +1486,8 @@ class EmojiCompat_GlyphChecker extends jni.JObject {
   late final jni.JObjType<EmojiCompat_GlyphChecker> $type = type;
 
   EmojiCompat_GlyphChecker.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_GlyphCheckerType();
@@ -1586,8 +1586,8 @@ class EmojiCompat_MetadataRepoLoader extends jni.JObject {
   late final jni.JObjType<EmojiCompat_MetadataRepoLoader> $type = type;
 
   EmojiCompat_MetadataRepoLoader.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_MetadataRepoLoaderType();
@@ -1649,8 +1649,8 @@ class EmojiCompat_InitCallback extends jni.JObject {
   late final jni.JObjType<EmojiCompat_InitCallback> $type = type;
 
   EmojiCompat_InitCallback.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_InitCallbackType();
@@ -1732,8 +1732,8 @@ class EmojiCompat_DefaultSpanFactory extends jni.JObject {
   late final jni.JObjType<EmojiCompat_DefaultSpanFactory> $type = type;
 
   EmojiCompat_DefaultSpanFactory.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_DefaultSpanFactoryType();
@@ -1812,8 +1812,8 @@ class EmojiCompat_SpanFactory extends jni.JObject {
   late final jni.JObjType<EmojiCompat_SpanFactory> $type = type;
 
   EmojiCompat_SpanFactory.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $EmojiCompat_SpanFactoryType();
@@ -1909,8 +1909,8 @@ class DefaultEmojiCompatConfig extends jni.JObject {
   late final jni.JObjType<DefaultEmojiCompatConfig> $type = type;
 
   DefaultEmojiCompatConfig.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $DefaultEmojiCompatConfigType();
@@ -1978,8 +1978,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28
       $type = type;
 
   DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API28.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type =
@@ -2065,8 +2065,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19
       $type = type;
 
   DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper_API19.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type =
@@ -2174,8 +2174,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper
       type;
 
   DefaultEmojiCompatConfig_DefaultEmojiCompatConfigHelper.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type =
@@ -2309,8 +2309,8 @@ class DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory
       $type = type;
 
   DefaultEmojiCompatConfig_DefaultEmojiCompatConfigFactory.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type =
@@ -2392,8 +2392,8 @@ class Build_Partition extends jni.JObject {
   late final jni.JObjType<Build_Partition> $type = type;
 
   Build_Partition.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Build_PartitionType();
@@ -2494,8 +2494,8 @@ class Build_VERSION extends jni.JObject {
   late final jni.JObjType<Build_VERSION> $type = type;
 
   Build_VERSION.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Build_VERSIONType();
@@ -2646,8 +2646,8 @@ class Build_VERSION_CODES extends jni.JObject {
   late final jni.JObjType<Build_VERSION_CODES> $type = type;
 
   Build_VERSION_CODES.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Build_VERSION_CODESType();
@@ -2797,8 +2797,8 @@ class Build extends jni.JObject {
   late final jni.JObjType<Build> $type = type;
 
   Build.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $BuildType();
@@ -3150,8 +3150,8 @@ class HashMap<$K extends jni.JObject, $V extends jni.JObject>
   HashMap.fromRef(
     this.K,
     this.V,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $HashMapType<$K, $V>

--- a/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
+++ b/jnigen/example/kotlin_plugin/lib/kotlin_bindings.dart
@@ -32,8 +32,8 @@ class Example extends jni.JObject {
   late final jni.JObjType<Example> $type = type;
 
   Example.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $ExampleType();

--- a/jnigen/example/notification_plugin/lib/notifications.dart
+++ b/jnigen/example/notification_plugin/lib/notifications.dart
@@ -36,8 +36,8 @@ class Notifications extends jni.JObject {
   late final jni.JObjType<Notifications> $type = type;
 
   Notifications.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $NotificationsType();

--- a/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
+++ b/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocument.dart
@@ -52,8 +52,8 @@ class PDDocument extends jni.JObject {
   late final jni.JObjType<PDDocument> $type = type;
 
   PDDocument.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $PDDocumentType();

--- a/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
+++ b/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/pdmodel/PDDocumentInformation.dart
@@ -53,8 +53,8 @@ class PDDocumentInformation extends jni.JObject {
   late final jni.JObjType<PDDocumentInformation> $type = type;
 
   PDDocumentInformation.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $PDDocumentInformationType();

--- a/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
+++ b/jnigen/example/pdfbox_plugin/lib/src/third_party/org/apache/pdfbox/text/PDFTextStripper.dart
@@ -56,8 +56,8 @@ class PDFTextStripper extends jni.JObject {
   late final jni.JObjType<PDFTextStripper> $type = type;
 
   PDFTextStripper.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $PDFTextStripperType();

--- a/jnigen/lib/src/bindings/dart_generator.dart
+++ b/jnigen/lib/src/bindings/dart_generator.dart
@@ -355,10 +355,9 @@ class $name$typeParamsDef extends $superName {
 
   $name.fromRef(
     $ctorTypeClassesDef
-    $_jPointer ref,
+    super.reference,
   ): super.fromRef(
     $superTypeClassesCall
-    ref
   );
 
 ''');

--- a/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -65,8 +65,8 @@ class JsonFactory extends jni.JObject {
   late final jni.JObjType<JsonFactory> $type = type;
 
   JsonFactory.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $JsonFactoryType();
@@ -1887,8 +1887,8 @@ class JsonFactory_Feature extends jni.JObject {
   late final jni.JObjType<JsonFactory_Feature> $type = type;
 
   JsonFactory_Feature.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $JsonFactory_FeatureType();

--- a/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -52,8 +52,8 @@ class JsonParser extends jni.JObject {
   late final jni.JObjType<JsonParser> $type = type;
 
   JsonParser.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $JsonParserType();
@@ -2668,8 +2668,8 @@ class JsonParser_Feature extends jni.JObject {
   late final jni.JObjType<JsonParser_Feature> $type = type;
 
   JsonParser_Feature.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $JsonParser_FeatureType();
@@ -2785,8 +2785,8 @@ class JsonParser_NumberType extends jni.JObject {
   late final jni.JObjType<JsonParser_NumberType> $type = type;
 
   JsonParser_NumberType.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $JsonParser_NumberTypeType();

--- a/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/jnigen/test/jackson_core_test/third_party/c_based/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -49,8 +49,8 @@ class JsonToken extends jni.JObject {
   late final jni.JObjType<JsonToken> $type = type;
 
   JsonToken.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $JsonTokenType();

--- a/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
+++ b/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonFactory.dart
@@ -64,8 +64,8 @@ class JsonFactory extends jni.JObject {
   late final jni.JObjType<JsonFactory> $type = type;
 
   JsonFactory.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/fasterxml/jackson/core/JsonFactory");
@@ -1789,8 +1789,8 @@ class JsonFactory_Feature extends jni.JObject {
   late final jni.JObjType<JsonFactory_Feature> $type = type;
 
   JsonFactory_Feature.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/fasterxml/jackson/core/JsonFactory$Feature");

--- a/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
+++ b/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonParser.dart
@@ -51,8 +51,8 @@ class JsonParser extends jni.JObject {
   late final jni.JObjType<JsonParser> $type = type;
 
   JsonParser.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/fasterxml/jackson/core/JsonParser");
@@ -2521,8 +2521,8 @@ class JsonParser_Feature extends jni.JObject {
   late final jni.JObjType<JsonParser_Feature> $type = type;
 
   JsonParser_Feature.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/fasterxml/jackson/core/JsonParser$Feature");
@@ -2635,8 +2635,8 @@ class JsonParser_NumberType extends jni.JObject {
   late final jni.JObjType<JsonParser_NumberType> $type = type;
 
   JsonParser_NumberType.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/fasterxml/jackson/core/JsonParser$NumberType");

--- a/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
+++ b/jnigen/test/jackson_core_test/third_party/dart_only/dart_bindings/com/fasterxml/jackson/core/JsonToken.dart
@@ -47,8 +47,8 @@ class JsonToken extends jni.JObject {
   late final jni.JObjType<JsonToken> $type = type;
 
   JsonToken.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/fasterxml/jackson/core/JsonToken");

--- a/jnigen/test/kotlin_test/c_based/dart_bindings/kotlin.dart
+++ b/jnigen/test/kotlin_test/c_based/dart_bindings/kotlin.dart
@@ -36,8 +36,8 @@ class SuspendFun extends jni.JObject {
   late final jni.JObjType<SuspendFun> $type = type;
 
   SuspendFun.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $SuspendFunType();

--- a/jnigen/test/kotlin_test/dart_only/dart_bindings/kotlin.dart
+++ b/jnigen/test/kotlin_test/dart_only/dart_bindings/kotlin.dart
@@ -31,8 +31,8 @@ class SuspendFun extends jni.JObject {
   late final jni.JObjType<SuspendFun> $type = type;
 
   SuspendFun.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/SuspendFun");

--- a/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/c_based/dart_bindings/simple_package.dart
@@ -36,8 +36,8 @@ class Color extends jni.JObject {
   late final jni.JObjType<Color> $type = type;
 
   Color.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $ColorType();
@@ -96,8 +96,8 @@ class Example extends jni.JObject {
   late final jni.JObjType<Example> $type = type;
 
   Example.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $ExampleType();
@@ -810,8 +810,8 @@ class Example_Nested extends jni.JObject {
   late final jni.JObjType<Example_Nested> $type = type;
 
   Example_Nested.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Example_NestedType();
@@ -896,8 +896,8 @@ class Example_Nested_NestedTwice extends jni.JObject {
   late final jni.JObjType<Example_Nested_NestedTwice> $type = type;
 
   Example_Nested_NestedTwice.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Example_Nested_NestedTwiceType();
@@ -962,8 +962,8 @@ class Example_NonStaticNested extends jni.JObject {
   late final jni.JObjType<Example_NonStaticNested> $type = type;
 
   Example_NonStaticNested.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Example_NonStaticNestedType();
@@ -1038,8 +1038,8 @@ class Exceptions extends jni.JObject {
   late final jni.JObjType<Exceptions> $type = type;
 
   Exceptions.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $ExceptionsType();
@@ -1280,8 +1280,8 @@ class Fields extends jni.JObject {
   late final jni.JObjType<Fields> $type = type;
 
   Fields.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $FieldsType();
@@ -1535,8 +1535,8 @@ class Fields_Nested extends jni.JObject {
   late final jni.JObjType<Fields_Nested> $type = type;
 
   Fields_Nested.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Fields_NestedType();
@@ -1626,8 +1626,8 @@ class C2 extends jni.JObject {
   late final jni.JObjType<C2> $type = type;
 
   C2.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $C2Type();
@@ -1688,8 +1688,8 @@ class Example1 extends jni.JObject {
   late final jni.JObjType<Example1> $type = type;
 
   Example1.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $Example1Type();
@@ -1751,8 +1751,8 @@ class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
   GenericTypeParams.fromRef(
     this.S,
     this.K,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $GenericTypeParamsType<$S, $K>
@@ -1825,8 +1825,8 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
 
   GrandParent.fromRef(
     this.T,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $GrandParentType<$T> type<$T extends jni.JObject>(
@@ -2002,8 +2002,8 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
   GrandParent_Parent.fromRef(
     this.T,
     this.S,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $GrandParent_ParentType<$T, $S>
@@ -2147,8 +2147,8 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
     this.T,
     this.S,
     this.U,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $GrandParent_Parent_ChildType<$T, $S, $U> type<$T extends jni.JObject,
@@ -2324,8 +2324,8 @@ class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
 
   GrandParent_StaticParent.fromRef(
     this.S,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $GrandParent_StaticParentType<$S> type<$S extends jni.JObject>(
@@ -2427,8 +2427,8 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
   GrandParent_StaticParent_Child.fromRef(
     this.S,
     this.U,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $GrandParent_StaticParent_ChildType<$S, $U>
@@ -2577,8 +2577,8 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
   MyMap.fromRef(
     this.K,
     this.V,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $MyMapType<$K, $V>
@@ -2699,8 +2699,8 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
   MyMap_MyEntry.fromRef(
     this.K,
     this.V,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $MyMap_MyEntryType<$K, $V>
@@ -2841,8 +2841,8 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
 
   MyStack.fromRef(
     this.T,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $MyStackType<$T> type<$T extends jni.JObject>(
@@ -3036,8 +3036,11 @@ class StringKeyedMap<$V extends jni.JObject> extends MyMap<jni.JString, $V> {
 
   StringKeyedMap.fromRef(
     this.V,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(const jni.JStringType(), V, ref);
+    super.reference,
+  ) : super.fromRef(
+          const jni.JStringType(),
+          V,
+        );
 
   /// The type which includes information such as the signature of this class.
   static $StringKeyedMapType<$V> type<$V extends jni.JObject>(
@@ -3100,8 +3103,10 @@ class StringMap extends StringKeyedMap<jni.JString> {
   late final jni.JObjType<StringMap> $type = type;
 
   StringMap.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(const jni.JStringType(), ref);
+    super.reference,
+  ) : super.fromRef(
+          const jni.JStringType(),
+        );
 
   /// The type which includes information such as the signature of this class.
   static const type = $StringMapType();
@@ -3146,8 +3151,10 @@ class StringStack extends MyStack<jni.JString> {
   late final jni.JObjType<StringStack> $type = type;
 
   StringStack.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(const jni.JStringType(), ref);
+    super.reference,
+  ) : super.fromRef(
+          const jni.JStringType(),
+        );
 
   /// The type which includes information such as the signature of this class.
   static const type = $StringStackType();
@@ -3195,8 +3202,11 @@ class StringValuedMap<$K extends jni.JObject> extends MyMap<$K, jni.JString> {
 
   StringValuedMap.fromRef(
     this.K,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(K, const jni.JStringType(), ref);
+    super.reference,
+  ) : super.fromRef(
+          K,
+          const jni.JStringType(),
+        );
 
   /// The type which includes information such as the signature of this class.
   static $StringValuedMapType<$K> type<$K extends jni.JObject>(
@@ -3262,8 +3272,8 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
 
   MyInterface.fromRef(
     this.T,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static $MyInterfaceType<$T> type<$T extends jni.JObject>(
@@ -3539,8 +3549,8 @@ class MyInterfaceConsumer extends jni.JObject {
   late final jni.JObjType<MyInterfaceConsumer> $type = type;
 
   MyInterfaceConsumer.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $MyInterfaceConsumerType();
@@ -3658,8 +3668,8 @@ class MyRunnable extends jni.JObject {
   late final jni.JObjType<MyRunnable> $type = type;
 
   MyRunnable.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $MyRunnableType();
@@ -3794,8 +3804,8 @@ class MyRunnableRunner extends jni.JObject {
   late final jni.JObjType<MyRunnableRunner> $type = type;
 
   MyRunnableRunner.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $MyRunnableRunnerType();
@@ -3895,8 +3905,8 @@ class JsonSerializable_Case extends jni.JObject {
   late final jni.JObjType<JsonSerializable_Case> $type = type;
 
   JsonSerializable_Case.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $JsonSerializable_CaseType();
@@ -3962,8 +3972,8 @@ class MyDataClass extends jni.JObject {
   late final jni.JObjType<MyDataClass> $type = type;
 
   MyDataClass.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   /// The type which includes information such as the signature of this class.
   static const type = $MyDataClassType();

--- a/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
+++ b/jnigen/test/simple_package_test/dart_only/dart_bindings/simple_package.dart
@@ -31,8 +31,8 @@ class Color extends jni.JObject {
   late final jni.JObjType<Color> $type = type;
 
   Color.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/simple_package/Color");
@@ -98,8 +98,8 @@ class Example extends jni.JObject {
   late final jni.JObjType<Example> $type = type;
 
   Example.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/simple_package/Example");
@@ -749,8 +749,8 @@ class Example_Nested extends jni.JObject {
   late final jni.JObjType<Example_Nested> $type = type;
 
   Example_Nested.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/simple_package/Example$Nested");
@@ -831,8 +831,8 @@ class Example_Nested_NestedTwice extends jni.JObject {
   late final jni.JObjType<Example_Nested_NestedTwice> $type = type;
 
   Example_Nested_NestedTwice.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/simple_package/Example$Nested$NestedTwice");
@@ -899,8 +899,8 @@ class Example_NonStaticNested extends jni.JObject {
   late final jni.JObjType<Example_NonStaticNested> $type = type;
 
   Example_NonStaticNested.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/simple_package/Example$NonStaticNested");
@@ -969,8 +969,8 @@ class Exceptions extends jni.JObject {
   late final jni.JObjType<Exceptions> $type = type;
 
   Exceptions.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/simple_package/Exceptions");
@@ -1203,8 +1203,8 @@ class Fields extends jni.JObject {
   late final jni.JObjType<Fields> $type = type;
 
   Fields.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/simple_package/Fields");
@@ -1414,8 +1414,8 @@ class Fields_Nested extends jni.JObject {
   late final jni.JObjType<Fields_Nested> $type = type;
 
   Fields_Nested.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/simple_package/Fields$Nested");
@@ -1499,8 +1499,8 @@ class C2 extends jni.JObject {
   late final jni.JObjType<C2> $type = type;
 
   C2.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/pkg2/C2");
@@ -1563,8 +1563,8 @@ class Example1 extends jni.JObject {
   late final jni.JObjType<Example1> $type = type;
 
   Example1.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/pkg2/Example");
@@ -1627,8 +1627,8 @@ class GenericTypeParams<$S extends jni.JObject, $K extends jni.JObject>
   GenericTypeParams.fromRef(
     this.S,
     this.K,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/generics/GenericTypeParams");
@@ -1707,8 +1707,8 @@ class GrandParent<$T extends jni.JObject> extends jni.JObject {
 
   GrandParent.fromRef(
     this.T,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/generics/GrandParent");
@@ -1878,8 +1878,8 @@ class GrandParent_Parent<$T extends jni.JObject, $S extends jni.JObject>
   GrandParent_Parent.fromRef(
     this.T,
     this.S,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/generics/GrandParent$Parent");
@@ -2008,8 +2008,8 @@ class GrandParent_Parent_Child<$T extends jni.JObject, $S extends jni.JObject,
     this.T,
     this.S,
     this.U,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/generics/GrandParent$Parent$Child");
@@ -2160,8 +2160,8 @@ class GrandParent_StaticParent<$S extends jni.JObject> extends jni.JObject {
 
   GrandParent_StaticParent.fromRef(
     this.S,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/generics/GrandParent$StaticParent");
@@ -2257,8 +2257,8 @@ class GrandParent_StaticParent_Child<$S extends jni.JObject,
   GrandParent_StaticParent_Child.fromRef(
     this.S,
     this.U,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/generics/GrandParent$StaticParent$Child");
@@ -2390,8 +2390,8 @@ class MyMap<$K extends jni.JObject, $V extends jni.JObject>
   MyMap.fromRef(
     this.K,
     this.V,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/generics/MyMap");
@@ -2510,8 +2510,8 @@ class MyMap_MyEntry<$K extends jni.JObject, $V extends jni.JObject>
   MyMap_MyEntry.fromRef(
     this.K,
     this.V,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/generics/MyMap$MyEntry");
@@ -2637,8 +2637,8 @@ class MyStack<$T extends jni.JObject> extends jni.JObject {
 
   MyStack.fromRef(
     this.T,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/generics/MyStack");
@@ -2837,8 +2837,11 @@ class StringKeyedMap<$V extends jni.JObject> extends MyMap<jni.JString, $V> {
 
   StringKeyedMap.fromRef(
     this.V,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(const jni.JStringType(), V, ref);
+    super.reference,
+  ) : super.fromRef(
+          const jni.JStringType(),
+          V,
+        );
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/generics/StringKeyedMap");
@@ -2906,8 +2909,10 @@ class StringMap extends StringKeyedMap<jni.JString> {
   late final jni.JObjType<StringMap> $type = type;
 
   StringMap.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(const jni.JStringType(), ref);
+    super.reference,
+  ) : super.fromRef(
+          const jni.JStringType(),
+        );
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/generics/StringMap");
@@ -2955,8 +2960,10 @@ class StringStack extends MyStack<jni.JString> {
   late final jni.JObjType<StringStack> $type = type;
 
   StringStack.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(const jni.JStringType(), ref);
+    super.reference,
+  ) : super.fromRef(
+          const jni.JStringType(),
+        );
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/generics/StringStack");
@@ -3007,8 +3014,11 @@ class StringValuedMap<$K extends jni.JObject> extends MyMap<$K, jni.JString> {
 
   StringValuedMap.fromRef(
     this.K,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(K, const jni.JStringType(), ref);
+    super.reference,
+  ) : super.fromRef(
+          K,
+          const jni.JStringType(),
+        );
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/generics/StringValuedMap");
@@ -3079,8 +3089,8 @@ class MyInterface<$T extends jni.JObject> extends jni.JObject {
 
   MyInterface.fromRef(
     this.T,
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/interfaces/MyInterface");
@@ -3348,8 +3358,8 @@ class MyInterfaceConsumer extends jni.JObject {
   late final jni.JObjType<MyInterfaceConsumer> $type = type;
 
   MyInterfaceConsumer.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/interfaces/MyInterfaceConsumer");
@@ -3464,8 +3474,8 @@ class MyRunnable extends jni.JObject {
   late final jni.JObjType<MyRunnable> $type = type;
 
   MyRunnable.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class =
       jni.Jni.findJClass(r"com/github/dart_lang/jnigen/interfaces/MyRunnable");
@@ -3601,8 +3611,8 @@ class MyRunnableRunner extends jni.JObject {
   late final jni.JObjType<MyRunnableRunner> $type = type;
 
   MyRunnableRunner.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/interfaces/MyRunnableRunner");
@@ -3689,8 +3699,8 @@ class JsonSerializable_Case extends jni.JObject {
   late final jni.JObjType<JsonSerializable_Case> $type = type;
 
   JsonSerializable_Case.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/annotations/JsonSerializable$Case");
@@ -3760,8 +3770,8 @@ class MyDataClass extends jni.JObject {
   late final jni.JObjType<MyDataClass> $type = type;
 
   MyDataClass.fromRef(
-    jni.JObjectPtr ref,
-  ) : super.fromRef(ref);
+    super.reference,
+  ) : super.fromRef();
 
   static final _class = jni.Jni.findJClass(
       r"com/github/dart_lang/jnigen/annotations/MyDataClass");


### PR DESCRIPTION
Minor refactoring to use the newer Dart features in both the generated code and in `package:jni` classes.

WIP: There is still some issues with subclasses in the generated code.