### PR TITLE
Fix buffer overflow issue when converting strings from JNI to Dart

### DIFF
--- a/jni/CHANGELOG.md
+++ b/jni/CHANGELOG.md
@@ -19,6 +19,9 @@
 - **Breaking Change**: `JArray.filled` now uses the generated type class of the
   `fill` object and not its Java runtime type.
 
+## 0.7.2
+- Fixed a bug where reading non-null terminated strings would overflow.
+
 ## 0.7.1
 - Removed macOS Flutter plugin until package:jni supports it ([#41](https://github.com/dart-lang/jnigen/issues/41)).
 

--- a/jni/lib/src/jni.dart
+++ b/jni/lib/src/jni.dart
@@ -330,8 +330,7 @@ extension ProtectedJniExtensions on Jni {
 }
 
 extension AdditionalEnvMethods on GlobalJniEnv {
-  /// Convenience method for converting a [JStringPtr]
-  /// to dart string.
+  /// Convenience method for converting a [JStringPtr] to dart string.
   /// if [releaseOriginal] is specified, jstring passed will be deleted using
   /// DeleteGlobalRef.
   String toDartString(JStringPtr jstringPtr, {bool releaseOriginal = false}) {
@@ -342,7 +341,8 @@ extension AdditionalEnvMethods on GlobalJniEnv {
     if (chars == nullptr) {
       throw ArgumentError('Not a valid jstring pointer.');
     }
-    final result = chars.cast<Utf16>().toDartString();
+    final length = GetStringLength(jstringPtr);
+    final result = chars.cast<Utf16>().toDartString(length: length);
     ReleaseStringChars(jstringPtr, chars);
     if (releaseOriginal) {
       DeleteGlobalRef(jstringPtr);
@@ -377,7 +377,7 @@ extension StringMethodsForJni on String {
 
 extension CharPtrMethodsForJni on Pointer<Char> {
   /// Same as calling `cast<Utf8>` followed by `toDartString`.
-  String toDartString() {
-    return cast<Utf8>().toDartString();
+  String toDartString({int? length}) {
+    return cast<Utf8>().toDartString(length: length);
   }
 }

--- a/jni/lib/src/lang/jstring.dart
+++ b/jni/lib/src/lang/jstring.dart
@@ -59,10 +59,7 @@ class JString extends JObject {
   /// after conversion and this object will be marked as released.
   String toDartString({bool releaseOriginal = false}) {
     ensureNotNull();
-    final length = Jni.env.GetStringLength(reference);
-    final chars = Jni.env.GetStringChars(reference, nullptr);
-    final result = chars.cast<Utf16>().toDartString(length: length);
-    Jni.env.ReleaseStringChars(reference, chars);
+    final result = Jni.env.toDartString(reference);
     if (releaseOriginal) {
       release();
     }

--- a/jni/lib/src/lang/jstring.dart
+++ b/jni/lib/src/lang/jstring.dart
@@ -4,7 +4,6 @@
 
 import 'dart:ffi';
 
-import 'package:ffi/ffi.dart';
 import 'package:jni/src/jreference.dart';
 
 import '../jni.dart';


### PR DESCRIPTION
Test out this flutter app with jni: 0.7.0 on an Android device and you will receive the following output:
```plain
Launching lib\main.dart on Pixel 4 in debug mode...
Running Gradle task 'assembleDebug'...
√  Built build\app\outputs\flutter-apk\app-debug.apk.
Installing build\app\outputs\flutter-apk\app-debug.apk...
Debug service listening on ws://127.0.0.1:59650/oKyS4sWS_K4=/ws
Syncing files to device Pixel 4...
I/flutter (10682): packageName: com.example.jnitest됀
```

```dart
import 'package:flutter/material.dart';
import 'package:jni/jni.dart';

void main() {
  WidgetsFlutterBinding.ensureInitialized();
  final obj = JObject.fromRef(Jni.getCurrentActivity());
  final packageName = obj.callMethodByName<String>(
    'getPackageName',
    '()Ljava/lang/String;',
    [],
  );
  print('packageName: $packageName');
}
```

Notice the string has extra characters at the end: `com.example.jnitest됀` of the package name.

This is because the current implementation overflows when reading the characters for strings. If the memory for the string originates in a buffer that was null terminated this is not an issue. But this cannot be guaranteed. Instead this PR patches the requirement to fetch the length of the string before we read the characters. 

This run over on reading can lead to an infinite-loop/crash on reading as it will either carry on reading into invalid memory or simply overrun at some point. Edit: I have also experience random crashes in the wild due to this as well.

It is also good to note that the official [JNI docs for GetStringChars](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetStringChars) does not mention the returned jchar* as being null terminated. So we should not expect it.

There was two places in the code that `toDartString` was implemented. This was also part of the underlying cause because the two implementations were different. This PR also patches the code so that one calls the other and they both end up using the same implementation. 

I have also ensured the tests are updated to validate UTF-8 and UTF-16 implementations. I wanted to test the unhappy case where the originating string is not null terminated, but with strings created on my local machine I cannot replicate. I can however replicate on Android as the test above shows. 

@HosseinYousefi I see you are working on 0.8.0 so I have chosen not to update the CHANGELOG or pubspec and let you do that as required. 